### PR TITLE
Validate ESP-NOW channel before initialization

### DIFF
--- a/firmware/controller/src/gagguino.cpp
+++ b/firmware/controller/src/gagguino.cpp
@@ -1167,6 +1167,17 @@ static void initEspNow() {
         return;
     }
 
+    if (channel < 1 || channel > 13) {
+        LOG_ERROR("ESP-NOW: invalid channel %u", channel);
+        g_espnowStatus = "error";
+        g_espnowChannel = 0;
+        if (mqttClient.connected()) {
+            publishStr(t_espnow_state, g_espnowStatus, true);
+            publishNum(t_espnow_chan_state, g_espnowChannel, 0, true);
+        }
+        return;
+    }
+
     // Only initialise ESP-NOW once and update the broadcast peer on subsequent
     // Wi-Fi reconnects. Repeated init/deinit was causing log spam and Wi-Fi
     // churn, which in turn dropped the MQTT session.


### PR DESCRIPTION
## Summary
- Validate Wi-Fi channel is within 1-13 before starting ESP-NOW
- Report invalid channel via MQTT with espnow/channel=0 and skip initialization

## Testing
- `pio run -e esp32dev` *(fails: command not found)*
- `pip install platformio` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b34dcd648330ad20ef5a4a9f4028