### PR TITLE
Increase FreeRTOS timer service stack

### DIFF
--- a/firmware/controller/platformio.ini
+++ b/firmware/controller/platformio.ini
@@ -20,9 +20,10 @@ lib_deps =
   adafruit/Adafruit MAX31865 library
   knolleary/PubSubClient
 monitor_speed = 115200
-build_flags = 
+build_flags =
   -I ../shared/include
   -I ../secrets/include
+  -D CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=4096 ; enlarge timer service stack to avoid overflow
 
 
 [env:esp32dev_ota]


### PR DESCRIPTION
## Summary
- raise FreeRTOS timer service stack depth to prevent `Tmr Svc` overflows

## Testing
- ⚠️ `pio run -e esp32dev` *(command not found and `pip install platformio` blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dfaf04648330bad67fabfb6484c6