### PR TITLE
Override FreeRTOS timer stack depth

### DIFF
--- a/firmware/controller/include/sdkconfig.h
+++ b/firmware/controller/include/sdkconfig.h
@@ -1,0 +1,4 @@
+#pragma once
+#include_next "sdkconfig.h"
+#undef CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH
+#define CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH 4096

--- a/firmware/controller/platformio.ini
+++ b/firmware/controller/platformio.ini
@@ -23,7 +23,7 @@ monitor_speed = 115200
 build_flags =
   -I ../shared/include
   -I ../secrets/include
-  -D CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=4096 ; enlarge timer service stack to avoid overflow
+  ; CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH set in include/sdkconfig.h
 
 
 [env:esp32dev_ota]


### PR DESCRIPTION
## Summary
- Override FreeRTOS timer stack depth to 4096 via custom `sdkconfig.h`
- Remove conflicting build flag and document override location

## Testing
- `pio run -e esp32dev` *(fails: command not found)*
- `pip install platformio` *(fails: Cannot connect to proxy (403))*

------
https://chatgpt.com/codex/tasks/task_e_68c1e0b59194833094dcd81ce3bbfda8