### PR TITLE
Construct MQTT URI at runtime

### DIFF
--- a/firmware/display/src/Wireless/Wireless.c
+++ b/firmware/display/src/Wireless/Wireless.c
@@ -277,12 +277,15 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base,
 // --- A: MQTT_Start (no periodic re-subscribe timer) --------------------------
 void MQTT_Start(void)
 {
-#if defined(MQTT_URI)
+#if defined(MQTT_HOST) && defined(MQTT_PORT)
     if (s_mqtt || !s_wifi_got_ip)
         return;
 
+    char mqtt_uri[64];
+    snprintf(mqtt_uri, sizeof(mqtt_uri), "mqtt://%s:%d", MQTT_HOST, MQTT_PORT);
+
     esp_mqtt_client_config_t cfg = {
-        .broker.address.uri = MQTT_URI,
+        .broker.address.uri = mqtt_uri,
         .session.last_will = {
 #ifdef MQTT_STATUS
             .topic = MQTT_STATUS,
@@ -321,7 +324,7 @@ void MQTT_Start(void)
     (void)s_mqtt;
     if (!s_wifi_got_ip)
         return;
-    printf("MQTT: MQTT_URI not defined in secrets.h; disabled\r\n");
+    printf("MQTT: MQTT_HOST or MQTT_PORT not defined in secrets.h; disabled\r\n");
 #endif
 }
 

--- a/firmware/secrets/include/secrets.example.h
+++ b/firmware/secrets/include/secrets.example.h
@@ -11,14 +11,9 @@
 #define WIFI_PASSWORD "4d9a4d4652"
 #define WIFI_PASS WIFI_PASSWORD /* alias */
 
-/* ===== MQTT (host/port + URI kept in sync) ===== */
+/* ===== MQTT ===== */
 #define MQTT_HOST "homeassistant.local"
 #define MQTT_PORT 1883
-
-/* helpers for URI building (avoid clash with ctype.h macros) */
-#define STR_HELPER(x)
-#define STR(x) STR_HELPER(x) #x
-#define MQTT_URI "mqtt://" MQTT_HOST ":" STR(MQTT_PORT)
 
 /* auth */
 #define MQTT_USERNAME "mqtt-user"


### PR DESCRIPTION
## Summary
- Build MQTT broker URI from host and port within `MQTT_Start` on the display
- Remove compile-time URI concatenation and helper macros from `secrets.example.h`

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: tunnel connection 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a18db8b48330be797c9a7938ae6a