### PR TITLE
Handle ESP-NOW timers in dedicated task

### DIFF
--- a/firmware/display/src/Wireless/Wireless.h
+++ b/firmware/display/src/Wireless/Wireless.h
@@ -13,8 +13,6 @@
 
 void Wireless_Init(void);
 void WIFI_Init(void *arg);
-// Call periodically from main loop to run deferred work
-void Wireless_Poll(void);
 // MQTT
 void MQTT_Start(void);
 esp_mqtt_client_handle_t MQTT_GetClient(void);

--- a/firmware/display/src/main.c
+++ b/firmware/display/src/main.c
@@ -57,7 +57,6 @@ void app_main(void)
     while (1) {
         // Raise task priority or reduce handler period to improve performance
         // Run lv_timer_handler every 250 ms
-        Wireless_Poll();
         vTaskDelay(pdMS_TO_TICKS(250));
         // Task running lv_timer_handler should have lower priority than that running `lv_tick_inc`
         lv_timer_handler();


### PR DESCRIPTION
## Summary
- Run a background wireless task to handle ESP-NOW timeouts and start requests
- Defer ping/handshake sends from timer callbacks to the new task
- Remove now-unnecessary `Wireless_Poll` call from the main loop

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a38e79c48330991b30bae899340e