### PR TITLE
Add RTC-backed timestamps and NTP sync to firmware logs

### DIFF
--- a/firmware/controller/src/gagguino.cpp
+++ b/firmware/controller/src/gagguino.cpp
@@ -33,6 +33,8 @@
 #include <cstdarg>
 #include <string.h>
 #include <map>
+#include <sys/time.h>
+#include <time.h>
 
 #include "secrets.h"  // WIFI_*, MQTT_*
 #include "mqtt_topics.h"  // GAG_TOPIC_ROOT
@@ -51,7 +53,13 @@ static inline void LOG(const char* fmt, ...) {
     va_start(args, fmt);
     vsnprintf(buf, sizeof(buf), fmt, args);
     va_end(args);
-    Serial.println(buf);
+    struct timeval tv;
+    gettimeofday(&tv, nullptr);
+    struct tm tm;
+    localtime_r(&tv.tv_sec, &tm);
+    char tbuf[32];
+    strftime(tbuf, sizeof(tbuf), "%Y-%m-%d %H:%M:%S", &tm);
+    Serial.printf("[%s.%03ld] %s\n", tbuf, tv.tv_usec / 1000, buf);
 }
 
 /**
@@ -130,7 +138,13 @@ static inline void LOG_ERROR(const char* fmt, ...) {
     va_start(args, fmt);
     vsnprintf(buf, sizeof(buf), fmt, args);
     va_end(args);
-    Serial.println(buf);
+    struct timeval tv;
+    gettimeofday(&tv, nullptr);
+    struct tm tm;
+    localtime_r(&tv.tv_sec, &tm);
+    char tbuf[32];
+    strftime(tbuf, sizeof(tbuf), "%Y-%m-%d %H:%M:%S", &tm);
+    Serial.printf("[%s.%03ld] %s\n", tbuf, tv.tv_usec / 1000, buf);
 
     if (!g_errorLog.isEmpty()) g_errorLog += '\n';
     g_errorLog += buf;
@@ -145,6 +159,18 @@ static inline void LOG_ERROR(const char* fmt, ...) {
     if (mqttClient.connected()) mqttClient.publish(MQTT_ERRORS, g_errorLog.c_str(), true);
 }
 
+static void syncClock() {
+    configTime(0, 0, "pool.ntp.org");
+    struct tm tm;
+    if (getLocalTime(&tm, 5000)) {
+        LOG("RTC: %04d-%02d-%02d %02d:%02d:%02d", tm.tm_year + 1900, tm.tm_mon + 1,
+            tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
+        g_clockSynced = true;
+    } else {
+        LOG_ERROR("RTC: sync failed");
+    }
+}
+
 // Temps / PID
 float currentTemp = 0.0f, lastTemp = 0.0f, pvFiltTemp = 0.0f;
 float brewSetpoint = 95.0f;           // HA-controllable (90–99)
@@ -157,6 +183,7 @@ float pGainTemp = P_GAIN_TEMP, iGainTemp = I_GAIN_TEMP, dGainTemp = D_GAIN_TEMP,
 int heatCycles = 0;
 bool heaterState = false;
 bool heaterEnabled = true;  // HA switch default ON at boot
+bool g_clockSynced = false;
 
 // Pressure
 int rawPress = 0;
@@ -1271,6 +1298,7 @@ static void ensureWifi() {
     if (now != WL_CONNECTED) {
         forceHeaterOff();
         g_espnowStatus = "disabled";
+        g_clockSynced = false;
     }
     if (now != last) {
         if (now == WL_CONNECTED) {
@@ -1280,6 +1308,7 @@ static void ensureWifi() {
             g_mqttIpResolved = false;
             resolveBrokerIfNeeded();
             initEspNow();
+            if (!g_clockSynced) syncClock();
         } else {
             LOG("WiFi: %s (code=%d) — reconnecting…", wifiStatusName(now), (int)now);
         }

--- a/firmware/display/src/EXIO/TCA9554PWR.c
+++ b/firmware/display/src/EXIO/TCA9554PWR.c
@@ -1,4 +1,5 @@
 #include "TCA9554PWR.h"
+#include "esp_log.h"
 /*****************************************************  Operation register REG   ****************************************************/   
 uint8_t Read_REG(uint8_t REG)                                // Read the value of the TCA9554PWR register REG
 {
@@ -63,8 +64,8 @@ void Set_EXIO(uint8_t Pin,uint8_t State)                  // Sets the level stat
             Data = (~(0x01 << (Pin-1)) & bitsStatus);  
         Write_REG(TCA9554_OUTPUT_REG,Data);
     }
-    else                                                                             
-        printf("Parameter error, please enter the correct parameter!\r\n");
+    else
+        ESP_LOGE("EXIO", "Parameter error, please enter the correct parameter!");
 
 }
 void Set_EXIOS(uint8_t PinState)                     // Set 7 pins to the PinState state such as :PinState=0x23, 0010 0011 state (the highest bit is not used)

--- a/firmware/display/src/LVGL_UI/LVGL_Example.c
+++ b/firmware/display/src/LVGL_UI/LVGL_Example.c
@@ -3,6 +3,7 @@
 #include <math.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include "esp_log.h"
 
 /* Fallback symbol definitions for environments where newer LVGL symbols are
  * not provided. These values correspond to Font Awesome code points and allow
@@ -720,7 +721,7 @@ void Backlight_adjustment_event_cb(lv_event_t *e)
     LVGL_Backlight_adjustment(Backlight);
   }
   else
-    printf("Volume out of range: %d\n", Backlight);
+    ESP_LOGW("LVGL", "Volume out of range: %d", Backlight);
 }
 
 void LVGL_Backlight_adjustment(uint8_t Backlight) { Set_Backlight(Backlight); }

--- a/firmware/display/src/SD_Card/SD_MMC.c
+++ b/firmware/display/src/SD_Card/SD_MMC.c
@@ -3,6 +3,8 @@
 #define EXAMPLE_MAX_CHAR_SIZE    64
 #define MOUNT_POINT "/sdcard"
 
+#include "esp_log.h"
+
 static const char *SD_TAG = "SD";
 
 uint32_t Flash_Size = 0;
@@ -126,9 +128,9 @@ void Flash_Searching(void)
     if(esp_flash_get_physical_size(NULL, &Flash_Size) == ESP_OK)
     {
         Flash_Size = Flash_Size / (uint32_t)(1024 * 1024);
-        printf("Flash size: %ld MB\n", Flash_Size);
+        ESP_LOGI(SD_TAG, "Flash size: %ld MB", Flash_Size);
     }
     else{
-        printf("Get flash size failed\n");
+        ESP_LOGE(SD_TAG, "Get flash size failed");
     }
 }


### PR DESCRIPTION
## Summary
- add common logger that prefixes messages with RTC timestamps
- sync device clocks via NTP when WiFi connects
- convert ad-hoc prints to centralized logging macros

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a9bedd448330bdf08c6f54e2e4df