### PR TITLE
Use ROM printf for log timestamping

### DIFF
--- a/firmware/controller/src/gagguino.cpp
+++ b/firmware/controller/src/gagguino.cpp
@@ -128,6 +128,8 @@ PubSubClient mqttClient(wifiClient);
 
 // Rolling buffer of recent significant error messages
 static String g_errorLog;
+// Tracks whether the RTC has successfully synchronized with NTP
+static bool g_clockSynced = false;
 
 /**
  * @brief Log a significant error and publish it via MQTT.
@@ -183,7 +185,6 @@ float pGainTemp = P_GAIN_TEMP, iGainTemp = I_GAIN_TEMP, dGainTemp = D_GAIN_TEMP,
 int heatCycles = 0;
 bool heaterState = false;
 bool heaterEnabled = true;  // HA switch default ON at boot
-bool g_clockSynced = false;
 
 // Pressure
 int rawPress = 0;

--- a/firmware/display/src/main.c
+++ b/firmware/display/src/main.c
@@ -11,6 +11,8 @@
 #include "esp_log.h"
 #include <sys/time.h>
 #include <time.h>
+#include <string.h>
+#include "esp_rom_sys.h"
 
 static int log_vprintf(const char *fmt, va_list args)
 {
@@ -28,7 +30,7 @@ static int log_vprintf(const char *fmt, va_list args)
     localtime_r(&tv.tv_sec, &tm);
     char tbuf[32];
     strftime(tbuf, sizeof(tbuf), "%Y-%m-%d %H:%M:%S", &tm);
-    return ets_printf("[%s.%03ld] %s", tbuf, tv.tv_usec / 1000, msg);
+    return esp_rom_printf("[%s.%03ld] %s", tbuf, tv.tv_usec / 1000, msg);
 }
 #include "TCA9554PWR.h"
 #include "ST7701S.h"


### PR DESCRIPTION
## Summary
- replace legacy `ets_printf` with `esp_rom_printf`
- include missing headers for string and ROM functions
- declare clock sync flag before use so build can complete

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68c2acf346248330a8884431e580e401