### PR TITLE
Use unique MQTT client IDs for controller and display

### DIFF
--- a/firmware/display/src/Wireless/Wireless.c
+++ b/firmware/display/src/Wireless/Wireless.c
@@ -337,8 +337,8 @@ void MQTT_Start(void)
 #ifdef MQTT_PASSWORD
             .authentication.password = MQTT_PASSWORD,
 #endif
-#ifdef MQTT_CLIENT_ID
-            .client_id = MQTT_CLIENT_ID,
+#ifdef MQTT_DISPLAY_CLIENT_ID
+            .client_id = MQTT_DISPLAY_CLIENT_ID,
 #endif
         },
     };

--- a/firmware/secrets/include/secrets.example.h
+++ b/firmware/secrets/include/secrets.example.h
@@ -21,9 +21,13 @@
 #define MQTT_USER MQTT_USERNAME /* aliases for legacy names */
 #define MQTT_PASS MQTT_PASSWORD
 
-/* client id */
-#define MQTT_CLIENT_ID "gaggia-device"
-#define MQTT_CLIENTID MQTT_CLIENT_ID /* alias */
+/* client ids */
+#define MQTT_CONTROLLER_CLIENT_ID "gaggia-controller"
+#define MQTT_DISPLAY_CLIENT_ID "gaggia-display"
+
+/* legacy aliases */
+#define MQTT_CLIENT_ID MQTT_CONTROLLER_CLIENT_ID
+#define MQTT_CLIENTID MQTT_CLIENT_ID
 
 /* ===== Topics ===== */
 #define MQTT_STATUS GAG_TOPIC_ROOT "/" GAGGIA_ID "/status"


### PR DESCRIPTION
## Summary
- Assign distinct MQTT client IDs for the controller (`gaggia-controller`) and the display (`gaggia-display`) to avoid disconnects
- Update display firmware to reference its dedicated client ID

## Testing
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b01f180c8330b1c6eebed983567c