### PR TITLE
Replace deprecated SNTP calls with esp_sntp API

### DIFF
--- a/firmware/display/src/Wireless/Wireless.c
+++ b/firmware/display/src/Wireless/Wireless.c
@@ -133,9 +133,9 @@ void WIFI_Init(void *arg)
     else
     {
         // Sync clock via NTP when WiFi connects
-        sntp_setoperatingmode(SNTP_OPMODE_POLL);
-        sntp_setservername(0, "pool.ntp.org");
-        sntp_init();
+        esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);
+        esp_sntp_setservername(0, "pool.ntp.org");
+        esp_sntp_init();
         time_t now = 0;
         struct tm timeinfo = {0};
         int retry = 0;


### PR DESCRIPTION
## Summary
- replace deprecated `sntp_*` calls with `esp_sntp_*` equivalents in wireless initialization

## Testing
- ⚠️ `pio run` *(command not found)*
- ⚠️ `pip install platformio` *(tunnel connection failed: 403 Forbidden)*
- ⚠️ `idf.py --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b1e0a9748330b77ae2b35b2df2d9