### PR TITLE
Handle ESP-NOW drops and publish last packet timestamp

### DIFF
--- a/firmware/display/src/Wireless/Wireless.h
+++ b/firmware/display/src/Wireless/Wireless.h
@@ -29,3 +29,4 @@ bool MQTT_GetSteamState(void);
 
 bool Wireless_UsingEspNow(void);
 bool Wireless_IsMQTTConnected(void);
+bool Wireless_ControllerStillSendingEspNow(void);


### PR DESCRIPTION
## Summary
- Track last ESP-NOW packet time on the controller and publish it to MQTT as `espnow/last`
- Monitor ESP-NOW activity on the display, restart MQTT on timeout, and query controller's last packet timestamp
- Expose helper to detect if controller is still transmitting via ESP-NOW and clear stale receive times on dropout

## Testing
- `pio run -e controller` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*
- `pio run -e display` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c326734a308330959f948787c79f90