### PR TITLE
feat: allow display steam control override

### DIFF
--- a/firmware/display/src/LVGL_UI/LVGL_Example.c
+++ b/firmware/display/src/LVGL_UI/LVGL_Example.c
@@ -40,6 +40,7 @@ static void back_event_cb(lv_event_t *e);
 static void draw_ticks_cb(lv_event_t *e);
 static void set_label_value(lv_obj_t *label, float value, const char *suffix);
 static void heater_event_cb(lv_event_t *e);
+static void steam_event_cb(lv_event_t *e);
 
 void example1_increase_lvgl_tick(lv_timer_t *t);
 /**********************
@@ -200,6 +201,12 @@ static void heater_event_cb(lv_event_t *e)
 {
   bool heater = MQTT_GetHeaterState();
   MQTT_SetHeaterState(!heater);
+}
+
+static void steam_event_cb(lv_event_t *e)
+{
+  bool steam = MQTT_GetSteamState();
+  MQTT_SetSteamState(!steam);
 }
 
 static void back_event_cb(lv_event_t *e) { lv_scr_load(main_screen); }
@@ -498,6 +505,7 @@ static void Status_create(lv_obj_t *parent)
   lv_obj_set_style_text_font(steam_label, &mdi_icons_40, 0);
   lv_label_set_text(steam_label, MDI_STEAM);
   lv_obj_center(steam_label);
+  lv_obj_add_event_cb(steam_btn, steam_event_cb, LV_EVENT_CLICKED, NULL);
 
   settings_btn = lv_btn_create(ctrl_container);
   lv_obj_set_size(settings_btn, 80, 80);

--- a/firmware/display/src/Wireless/Wireless.h
+++ b/firmware/display/src/Wireless/Wireless.h
@@ -26,6 +26,7 @@ float MQTT_GetShotVolume(void);
 bool MQTT_GetHeaterState(void);
 void MQTT_SetHeaterState(bool state);
 bool MQTT_GetSteamState(void);
+void MQTT_SetSteamState(bool state);
 
 bool Wireless_UsingEspNow(void);
 bool Wireless_IsMQTTConnected(void);

--- a/firmware/shared/mqtt_spec.md
+++ b/firmware/shared/mqtt_spec.md
@@ -16,6 +16,7 @@ MQTT topic hierarchy.  All topics are rooted at:
 | `heater/state` | pub by controller, sub by display | Heater on/off state |
 | `heater/set` | cmd to controller (display publishes) | Command to toggle heater |
 | `steam/state` | pub by controller | Steam switch state |
+| `steam/set` | cmd to controller (display publishes) | Command to toggle steam mode |
 | `current_temp/state` | pub by controller | Boiler temperature |
 | `set_temp/state` | pub by controller | Active temperature setpoint |
 | `pressure/state` | pub by controller | Boiler pressure (bar) |


### PR DESCRIPTION
## Summary
- add steam toggle button to display UI
- forward steam commands over MQTT/ESP-NOW to override hardware flag
- document new `steam/set` topic

## Testing
- `pio run` *(fails: command not found)*
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ec17a2e08330beb4b95285896bdf