### PR TITLE
Count both edges from flow sensor

### DIFF
--- a/firmware/controller/src/gagguino.cpp
+++ b/firmware/controller/src/gagguino.cpp
@@ -1537,7 +1537,10 @@ void setup() {
         LOG("Pressure Intercept reset to %f", pressInt);
     }
 
-    attachInterrupt(digitalPinToInterrupt(FLOW_PIN), flowInt, RISING);
+    // Count both rising and falling edges from the flow sensor to
+    // double the pulse resolution.  CHANGE triggers the ISR on any
+    // transition and `PULSE_MIN` guards against spurious bounce.
+    attachInterrupt(digitalPinToInterrupt(FLOW_PIN), flowInt, CHANGE);
     attachInterrupt(digitalPinToInterrupt(ZC_PIN), zcInt, RISING);
 
     pulseCount = 0;


### PR DESCRIPTION
## Summary
- trigger flow sensor ISR on CHANGE so rising and falling edges are counted

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c44149d69483309e6aedbef8483797