### PR TITLE
Disable steam when heater is off unless hardware switch active

### DIFF
--- a/firmware/controller/src/gagguino.cpp
+++ b/firmware/controller/src/gagguino.cpp
@@ -1087,13 +1087,19 @@ static void publishNumberStatesSnapshot() {
     publishNum(t_pump_state, pumpPower, 0, true);
 }
 
-// Helper: immediately disable the heater output and prevent PID updates
+// Helper: immediately disable the heater output and prevent PID updates.
+// Also disables steam unless hardware AC sense keeps it active.
 static void forceHeaterOff() {
     heaterEnabled = false;
     heatPower = 0.0f;
     heatCycles = PWM_CYCLE;
     digitalWrite(HEAT_PIN, LOW);
     heaterState = false;
+    if (!steamHwFlag) {
+        steamDispFlag = false;
+        steamFlag = false;
+        publishBool(t_steam_state, steamFlag, true);
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Stop steam when the heater is forced off unless the AC_SENS hardware switch requests steam

## Testing
- `pio test` *(fails: command not found)*
- `pip install platformio` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c537b9dc108330a673217350824d31