### PR TITLE
Show ESP-NOW connection progress on display

### DIFF
--- a/firmware/display/src/Wireless/Wireless.c
+++ b/firmware/display/src/Wireless/Wireless.c
@@ -657,6 +657,11 @@ bool Wireless_ControllerStillSendingEspNow(void)
     return s_mqtt_espnow_last > s_espnow_last_rx;
 }
 
+bool Wireless_IsEspNowActive(void)
+{
+    return s_espnow_active;
+}
+
 static void Wireless_Poll(void)
 {
     // Handle deferred ESP-NOW timeout actions

--- a/firmware/display/src/Wireless/Wireless.h
+++ b/firmware/display/src/Wireless/Wireless.h
@@ -31,3 +31,4 @@ void MQTT_SetSteamState(bool state);
 bool Wireless_UsingEspNow(void);
 bool Wireless_IsMQTTConnected(void);
 bool Wireless_ControllerStillSendingEspNow(void);
+bool Wireless_IsEspNowActive(void);


### PR DESCRIPTION
## Summary
- add `Wireless_IsEspNowActive` helper for checking ESP-NOW activity
- show "Connecting" or "Connected" with color under ESP-NOW label during handshake

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5382a3ccc833085898a6e7a9c9aed