### PR TITLE
Add shot definition settings section

### DIFF
--- a/firmware/display/src/LVGL_UI/LVGL_UI.c
+++ b/firmware/display/src/LVGL_UI/LVGL_UI.c
@@ -43,6 +43,9 @@ static void draw_ticks_cb(lv_event_t *e);
 static void heater_event_cb(lv_event_t *e);
 static void steam_event_cb(lv_event_t *e);
 static lv_obj_t *create_aligned_button_container(lv_obj_t *parent, uint8_t cols);
+static void shot_def_dd_event_cb(lv_event_t *e);
+static void shot_duration_slider_event_cb(lv_event_t *e);
+static void shot_volume_slider_event_cb(lv_event_t *e);
 
 void example1_increase_lvgl_tick(lv_timer_t *t);
 /**********************
@@ -86,6 +89,14 @@ static lv_obj_t *pressure_units_label;
 static lv_obj_t *shot_time_units_label;
 static lv_obj_t *shot_volume_units_label;
 lv_obj_t *Backlight_slider;
+static lv_obj_t *beep_on_shot_cb;
+static lv_obj_t *shot_def_dd;
+static lv_obj_t *shot_duration_label;
+static lv_obj_t *shot_duration_slider;
+static lv_obj_t *shot_duration_value;
+static lv_obj_t *shot_volume_label;
+static lv_obj_t *shot_volume_slider;
+static lv_obj_t *shot_volume_value;
 static lv_obj_t *conn_label;
 static lv_obj_t *conn_status_label;
 static int last_conn_type = -1;
@@ -238,6 +249,7 @@ static void Settings_create(void)
                                            LV_GRID_TEMPLATE_LAST};
   static lv_coord_t grid_main_row_dsc[] = {
       LV_GRID_CONTENT, LV_GRID_CONTENT, LV_GRID_CONTENT, LV_GRID_CONTENT,
+      LV_GRID_CONTENT, LV_GRID_CONTENT, LV_GRID_CONTENT,
       LV_GRID_FR(1), LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
   lv_obj_set_grid_dsc_array(settings_scr, grid_main_col_dsc, grid_main_row_dsc);
 
@@ -283,6 +295,79 @@ static void Settings_create(void)
   lv_obj_add_event_cb(sw, led_event_cb, LV_EVENT_VALUE_CHANGED, led);
   lv_obj_set_grid_cell(sw, LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_START, 3,
                        1);
+
+  lv_obj_t *shot_section_label = lv_label_create(settings_scr);
+  lv_label_set_text(shot_section_label, "Shot definition");
+  lv_obj_add_style(shot_section_label, &style_title, 0);
+  lv_obj_set_grid_cell(shot_section_label, LV_GRID_ALIGN_CENTER, 0, 2,
+                       LV_GRID_ALIGN_START, 4, 1);
+
+  beep_on_shot_cb = lv_checkbox_create(settings_scr);
+  lv_checkbox_set_text(beep_on_shot_cb, "Beep on shot");
+  lv_obj_set_grid_cell(beep_on_shot_cb, LV_GRID_ALIGN_START, 0, 2,
+                       LV_GRID_ALIGN_START, 5, 1);
+
+  lv_obj_t *shot_def_label = lv_label_create(settings_scr);
+  lv_label_set_text(shot_def_label, "Shot definition");
+  lv_obj_add_style(shot_def_label, &style_text_muted, 0);
+  lv_obj_set_grid_cell(shot_def_label, LV_GRID_ALIGN_CENTER, 0, 1,
+                       LV_GRID_ALIGN_START, 6, 1);
+
+  shot_def_dd = lv_dropdown_create(settings_scr);
+  lv_dropdown_set_options(shot_def_dd, "None\nTime\nVolume");
+  lv_dropdown_set_selected(shot_def_dd, 0);
+  lv_obj_set_width(shot_def_dd, 120);
+  lv_obj_set_grid_cell(shot_def_dd, LV_GRID_ALIGN_START, 1, 1,
+                       LV_GRID_ALIGN_START, 6, 1);
+  lv_obj_add_event_cb(shot_def_dd, shot_def_dd_event_cb, LV_EVENT_VALUE_CHANGED,
+                      NULL);
+
+  shot_duration_label = lv_label_create(settings_scr);
+  lv_label_set_text(shot_duration_label, "Shot Duration");
+  lv_obj_add_style(shot_duration_label, &style_text_muted, 0);
+  lv_obj_set_grid_cell(shot_duration_label, LV_GRID_ALIGN_CENTER, 0, 1,
+                       LV_GRID_ALIGN_START, 7, 1);
+
+  shot_duration_slider = lv_slider_create(settings_scr);
+  lv_obj_set_size(shot_duration_slider, 200, 35);
+  lv_slider_set_range(shot_duration_slider, 20, 40);
+  lv_slider_set_value(shot_duration_slider, 27, LV_ANIM_OFF);
+  lv_obj_add_event_cb(shot_duration_slider, shot_duration_slider_event_cb,
+                      LV_EVENT_VALUE_CHANGED, NULL);
+  lv_obj_set_grid_cell(shot_duration_slider, LV_GRID_ALIGN_START, 1, 1,
+                       LV_GRID_ALIGN_START, 7, 1);
+
+  shot_duration_value = lv_label_create(settings_scr);
+  lv_label_set_text(shot_duration_value, "27s");
+  lv_obj_align_to(shot_duration_value, shot_duration_slider, LV_ALIGN_OUT_RIGHT_MID,
+                  10, 0);
+
+  shot_volume_label = lv_label_create(settings_scr);
+  lv_label_set_text(shot_volume_label, "Shot Volume");
+  lv_obj_add_style(shot_volume_label, &style_text_muted, 0);
+  lv_obj_set_grid_cell(shot_volume_label, LV_GRID_ALIGN_CENTER, 0, 1,
+                       LV_GRID_ALIGN_START, 7, 1);
+
+  shot_volume_slider = lv_slider_create(settings_scr);
+  lv_obj_set_size(shot_volume_slider, 200, 35);
+  lv_slider_set_range(shot_volume_slider, 30, 60);
+  lv_slider_set_value(shot_volume_slider, 40, LV_ANIM_OFF);
+  lv_obj_add_event_cb(shot_volume_slider, shot_volume_slider_event_cb,
+                      LV_EVENT_VALUE_CHANGED, NULL);
+  lv_obj_set_grid_cell(shot_volume_slider, LV_GRID_ALIGN_START, 1, 1,
+                       LV_GRID_ALIGN_START, 7, 1);
+
+  shot_volume_value = lv_label_create(settings_scr);
+  lv_label_set_text(shot_volume_value, "40 ml");
+  lv_obj_align_to(shot_volume_value, shot_volume_slider, LV_ALIGN_OUT_RIGHT_MID,
+                  10, 0);
+
+  lv_obj_add_flag(shot_duration_label, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_add_flag(shot_duration_slider, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_add_flag(shot_duration_value, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_add_flag(shot_volume_label, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_add_flag(shot_volume_slider, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_add_flag(shot_volume_value, LV_OBJ_FLAG_HIDDEN);
 
   /* DRY: Reuse main page button alignment for settings page */
   lv_obj_t *ctrl_container = create_aligned_button_container(settings_scr, /*cols=*/2);
@@ -347,6 +432,15 @@ void Lvgl_Example1_close(void)
   conn_status_label = NULL;
   last_conn_type = -1;
   last_conn_status = -1;
+  Backlight_slider = NULL;
+  beep_on_shot_cb = NULL;
+  shot_def_dd = NULL;
+  shot_duration_label = NULL;
+  shot_duration_slider = NULL;
+  shot_duration_value = NULL;
+  shot_volume_label = NULL;
+  shot_volume_slider = NULL;
+  shot_volume_value = NULL;
 
   lv_style_reset(&style_text_muted);
   lv_style_reset(&style_title);
@@ -806,6 +900,54 @@ void Backlight_adjustment_event_cb(lv_event_t *e)
   }
   else
     ESP_LOGW("LVGL", "Volume out of range: %d", Backlight);
+}
+
+static void shot_def_dd_event_cb(lv_event_t *e)
+{
+  uint16_t sel = lv_dropdown_get_selected(lv_event_get_target(e));
+  switch (sel)
+  {
+  case 1: /* Time */
+    lv_obj_clear_flag(shot_duration_label, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(shot_duration_slider, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(shot_duration_value, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(shot_volume_label, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(shot_volume_slider, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(shot_volume_value, LV_OBJ_FLAG_HIDDEN);
+    break;
+  case 2: /* Volume */
+    lv_obj_clear_flag(shot_volume_label, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(shot_volume_slider, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(shot_volume_value, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(shot_duration_label, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(shot_duration_slider, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(shot_duration_value, LV_OBJ_FLAG_HIDDEN);
+    break;
+  default:
+    lv_obj_add_flag(shot_duration_label, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(shot_duration_slider, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(shot_duration_value, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(shot_volume_label, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(shot_volume_slider, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(shot_volume_value, LV_OBJ_FLAG_HIDDEN);
+    break;
+  }
+}
+
+static void shot_duration_slider_event_cb(lv_event_t *e)
+{
+  int val = lv_slider_get_value(lv_event_get_target(e));
+  char buf[8];
+  snprintf(buf, sizeof buf, "%ds", val);
+  lv_label_set_text(shot_duration_value, buf);
+}
+
+static void shot_volume_slider_event_cb(lv_event_t *e)
+{
+  int val = lv_slider_get_value(lv_event_get_target(e));
+  char buf[8];
+  snprintf(buf, sizeof buf, "%d ml", val);
+  lv_label_set_text(shot_volume_value, buf);
 }
 
 void LVGL_Backlight_adjustment(uint8_t Backlight) { Set_Backlight(Backlight); }


### PR DESCRIPTION
## Summary
- add "Shot definition" section to settings page with checkbox for beep
- allow choosing shot definition by time or volume and display appropriate slider
- show slider value and default selections

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c53b6ed3d48330b9192a5df6359a43