### PR TITLE
feat: show firmware version on display

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,30 @@
+name: Bump version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  bump:
+    if: "!contains(github.event.head_commit.message, 'chore: release')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Bump tag
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update version in firmware
+        run: |
+          version=${{ steps.tag.outputs.new_tag }}
+          version=${version#v}
+          sed -i "s/#define VERSION \".*\"/#define VERSION \"${version}\"/" firmware/shared/include/version.h
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -am "chore: release ${version}" || echo 'No changes'
+          git push

--- a/firmware/controller/src/gagguino.cpp
+++ b/firmware/controller/src/gagguino.cpp
@@ -42,8 +42,7 @@
 #include "espnow_packet.h"
 #include "mqtt_topics.h"  // GAG_TOPIC_ROOT
 #include "secrets.h"      // WIFI_*, MQTT_*
-
-#define VERSION "7.0"
+#include "version.h"
 #define STARTUP_WAIT 1000
 #define SERIAL_BAUD 115200
 

--- a/firmware/display/src/CMakeLists.txt
+++ b/firmware/display/src/CMakeLists.txt
@@ -33,6 +33,7 @@ idf_component_register(
         ${DEMO_MAIN_DIR}/Wireless
         ${DEMO_MAIN_DIR}/Buzzer
         ${DEMO_MAIN_DIR}/fonts
+        ${CMAKE_SOURCE_DIR}/../shared/include
     REQUIRES
         lvgl__lvgl
         bt

--- a/firmware/display/src/LVGL_UI/LVGL_UI.c
+++ b/firmware/display/src/LVGL_UI/LVGL_UI.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include "esp_log.h"
 #include "esp_system.h"
+#include "version.h"
 
 /* Fallback symbol definitions for environments where newer LVGL symbols are
  * not provided. These values correspond to Font Awesome code points and allow
@@ -43,6 +44,7 @@ static void draw_ticks_cb(lv_event_t *e);
 static void heater_event_cb(lv_event_t *e);
 static void steam_event_cb(lv_event_t *e);
 static lv_obj_t *create_aligned_button_container(lv_obj_t *parent, uint8_t cols);
+static void add_version_label(lv_obj_t *parent);
 
 void example1_increase_lvgl_tick(lv_timer_t *t);
 /**********************
@@ -316,6 +318,8 @@ static void Settings_create(void)
   lv_label_set_text(reset_text, "Reset");
   lv_obj_set_style_text_color(reset_text, lv_color_white(), 0);
   lv_obj_set_grid_cell(reset_text, LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_START, 1, 1);
+
+  add_version_label(settings_scr);
 }
 
 void Lvgl_Example1_close(void)
@@ -566,6 +570,8 @@ static void Status_create(lv_obj_t *parent)
 
   lv_obj_move_foreground(ctrl_container);
 
+  add_version_label(parent);
+
   /* Timer to drive UI updates */
   auto_step_timer = lv_timer_create(example1_increase_lvgl_tick, 100, NULL);
 }
@@ -809,6 +815,14 @@ void Backlight_adjustment_event_cb(lv_event_t *e)
 }
 
 void LVGL_Backlight_adjustment(uint8_t Backlight) { Set_Backlight(Backlight); }
+
+static void add_version_label(lv_obj_t *parent)
+{
+  lv_obj_t *ver = lv_label_create(parent);
+  lv_label_set_text_fmt(ver, "v%s", VERSION);
+  lv_obj_set_style_text_color(ver, lv_color_white(), 0);
+  lv_obj_align(ver, LV_ALIGN_BOTTOM_MID, 0, 0);
+}
 /* Create a button container aligned like the main page control row
  * - Centered horizontally
  * - Positioned at ~70% screen height (20% below center)

--- a/firmware/shared/include/version.h
+++ b/firmware/shared/include/version.h
@@ -1,0 +1,2 @@
+#pragma once
+#define VERSION "7.0"


### PR DESCRIPTION
## Summary
- display firmware version at bottom of every LVGL page
- centralize version string in shared header updated by CI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5471599d883308ffd23479a9c6685