### PR TITLE
Expose OTA enable control via MQTT and display

### DIFF
--- a/firmware/controller/src/gagguino.cpp
+++ b/firmware/controller/src/gagguino.cpp
@@ -285,7 +285,7 @@ char t_piddtau_state[96], t_piddtau_cmd[96];
 
 // Config topics
 char c_shotvol[128], c_settemp[128], c_curtemp[128], c_press[128], c_shottime[128], c_ota[128],
-    c_espnow[128], c_espnow_chan[128];
+    c_ota_switch[128], c_espnow[128], c_espnow_chan[128];
 char c_accnt[128], c_zccnt[128], c_pulsecnt[128];
 char c_pidp_number[128], c_pidi_number[128], c_pidd_number[128], c_pidg_number[128];
 char c_shot[128], c_preflow[128], c_steam[128];
@@ -378,6 +378,7 @@ static void resolveBrokerIfNeeded() {
 // ---------- OTA ----------
 // Forward declaration for MQTT publish helper used in OTA callbacks
 static void publishStr(const char* topic, const String& v, bool retain = true);
+static void publishBool(const char* topic, bool on, bool retain = true);
 /**
  * @brief Initialize ArduinoOTA once Wi‑Fi is connected.
  *
@@ -391,7 +392,7 @@ static void ensureOta() {
     if (otaActive && otaStart && (millis() - otaStart >= OTA_ENABLE_MS)) {
         otaActive = false;
         otaStart = 0;
-        publishStr(t_ota_state, "idle", true);
+        publishBool(t_ota_state, false, true);
         LOG("OTA: window expired");
     }
 
@@ -414,7 +415,7 @@ static void ensureOta() {
         LOG("OTA: Start (%s)", ArduinoOTA.getCommand() == U_FLASH ? "flash" : "fs");
         otaActive = true;  // signal loop to reduce load and suppress MQTT publishing
         otaStart = millis();
-        publishStr(t_ota_state, "active", true);
+        publishBool(t_ota_state, true, true);
         // Turn off heater to reduce power/noise during OTA
         digitalWrite(HEAT_PIN, LOW);
         heaterState = false;
@@ -423,7 +424,7 @@ static void ensureOta() {
         LOG("OTA: End");
         otaActive = false;
         otaStart = 0;
-        publishStr(t_ota_state, "idle", true);
+        publishBool(t_ota_state, false, true);
         // (Optional) re-attach interrupts if you detached them on start
         // attachInterrupt(digitalPinToInterrupt(FLOW_PIN), flowInt, CHANGE);
         // attachInterrupt(digitalPinToInterrupt(ZC_PIN), zcInt, RISING);
@@ -459,7 +460,7 @@ static void ensureOta() {
         LOG_ERROR("OTA: Error %d (%s)", (int)error, msg);
         otaActive = false;
         otaStart = 0;
-        publishStr(t_ota_state, "error", true);
+        publishBool(t_ota_state, false, true);
     });
 
     ArduinoOTA.begin();
@@ -827,6 +828,8 @@ static void buildTopics() {
     snprintf(c_shottime, sizeof(c_shottime), "%s/sensor/%s_shot_time/config", DISCOVERY_PREFIX,
              dev_id);
     snprintf(c_ota, sizeof(c_ota), "%s/sensor/%s_ota_status/config", DISCOVERY_PREFIX, dev_id);
+    snprintf(c_ota_switch, sizeof(c_ota_switch), "%s/switch/%s_ota/config", DISCOVERY_PREFIX,
+             dev_id);
     snprintf(c_espnow, sizeof(c_espnow), "%s/sensor/%s_espnow_status/config", DISCOVERY_PREFIX,
              dev_id);
     snprintf(c_espnow_chan, sizeof(c_espnow_chan), "%s/sensor/%s_espnow_channel/config",
@@ -1007,6 +1010,14 @@ static void publishDiscovery() {
             "\",\"pl_on\":\"ON\",\"pl_off\":\"OFF\",\"avty_t\":\"" + String(MQTT_STATUS) +
             "\",\"pl_avail\":\"online\",\"pl_not_avail\":\"offline\",\"dev\":" + dev + "}");
 
+    // --- switch: OTA window ---
+    publishRetained(
+        c_ota_switch,
+        String("{\"name\":\"OTA\",\"uniq_id\":\"") + dev_id + "_ota\",\"cmd_t\":\"" + t_ota_cmd +
+            "\",\"stat_t\":\"" + t_ota_state +
+            "\",\"pl_on\":\"ON\",\"pl_off\":\"OFF\",\"avty_t\":\"" + String(MQTT_STATUS) +
+            "\",\"pl_avail\":\"online\",\"pl_not_avail\":\"offline\",\"dev\":" + dev + "}");
+
     // --- numbers (controllable) ---
     publishRetained(
         c_brewset_number,
@@ -1160,6 +1171,7 @@ static void publishStates() {
     char espnow_last_buf[24];
     snprintf(espnow_last_buf, sizeof(espnow_last_buf), "%lu", g_lastEspnowEpoch);
     publishStr(t_espnow_last_state, espnow_last_buf, true);
+    publishBool(t_ota_state, otaActive, true);
 
     // flags
     publishBool(t_shot_state, shotFlag);
@@ -1341,11 +1353,11 @@ static void mqttCallback(char* topic, uint8_t* payload, unsigned int len) {
             LOG("HA: MQTT enabled");
         }
     }
-    if (strcmp(topic, t_ota_cmd) == 0) {
-        otaActive = true;
-        otaStart = millis();
-        publishStr(t_ota_state, "enabled", true);
-        LOG("HA: OTA enabled for %lus", OTA_ENABLE_MS / 1000);
+    if (parse_onoff(t_ota_cmd, hv)) {
+        otaActive = hv;
+        otaStart = otaActive ? millis() : 0;
+        publishBool(t_ota_state, otaActive, true);
+        LOG("HA: OTA -> %s", otaActive ? "ON" : "OFF");
     }
     if (changed) {
         if (!steamFlag) setTemp = brewSetpoint;  // if brewing, apply immediately

--- a/firmware/display/src/LVGL_UI/LVGL_UI.c
+++ b/firmware/display/src/LVGL_UI/LVGL_UI.c
@@ -42,6 +42,7 @@ static void reset_event_cb(lv_event_t *e);
 static void draw_ticks_cb(lv_event_t *e);
 static void heater_event_cb(lv_event_t *e);
 static void steam_event_cb(lv_event_t *e);
+static void ota_event_cb(lv_event_t *e);
 static lv_obj_t *create_aligned_button_container(lv_obj_t *parent, uint8_t cols);
 static void shot_def_dd_event_cb(lv_event_t *e);
 static void shot_duration_slider_event_cb(lv_event_t *e);
@@ -70,6 +71,7 @@ static lv_obj_t *main_screen;
 static lv_obj_t *settings_scr;
 static lv_obj_t *heater_btn;
 static lv_obj_t *steam_btn;
+static lv_obj_t *ota_btn;
 static lv_obj_t *settings_btn;
 static lv_coord_t tab_h_global;
 
@@ -224,6 +226,12 @@ static void steam_event_cb(lv_event_t *e)
   MQTT_SetSteamState(!steam);
 }
 
+static void ota_event_cb(lv_event_t *e)
+{
+  bool ota = MQTT_GetOtaState();
+  MQTT_SetOtaState(!ota);
+}
+
 static void reset_event_cb(lv_event_t *e)
 {
   esp_restart();
@@ -370,7 +378,7 @@ static void Settings_create(void)
   lv_obj_add_flag(shot_volume_value, LV_OBJ_FLAG_HIDDEN);
 
   /* DRY: Reuse main page button alignment for settings page */
-  lv_obj_t *ctrl_container = create_aligned_button_container(settings_scr, /*cols=*/2);
+  lv_obj_t *ctrl_container = create_aligned_button_container(settings_scr, /*cols=*/3);
 
   lv_obj_t *back_btn = lv_btn_create(ctrl_container);
   lv_obj_set_size(back_btn, 80, 80);
@@ -401,6 +409,21 @@ static void Settings_create(void)
   lv_label_set_text(reset_text, "Reset");
   lv_obj_set_style_text_color(reset_text, lv_color_white(), 0);
   lv_obj_set_grid_cell(reset_text, LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_START, 1, 1);
+
+  ota_btn = lv_btn_create(ctrl_container);
+  lv_obj_set_size(ota_btn, 80, 80);
+  lv_obj_set_style_border_width(ota_btn, 0, 0);
+  lv_obj_set_style_bg_color(ota_btn, lv_palette_main(LV_PALETTE_GREY), 0);
+  lv_obj_set_grid_cell(ota_btn, LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_CENTER, 0, 1);
+  lv_obj_t *ota_label = lv_label_create(ota_btn);
+  lv_label_set_text(ota_label, "OTA");
+  lv_obj_center(ota_label);
+  lv_obj_add_event_cb(ota_btn, ota_event_cb, LV_EVENT_CLICKED, NULL);
+
+  lv_obj_t *ota_text = lv_label_create(ctrl_container);
+  lv_label_set_text(ota_text, "OTA");
+  lv_obj_set_style_text_color(ota_text, lv_color_white(), 0);
+  lv_obj_set_grid_cell(ota_text, LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_START, 1, 1);
 }
 
 void Lvgl_Example1_close(void)
@@ -750,6 +773,7 @@ void example1_increase_lvgl_tick(lv_timer_t *t)
   float shot_vol = MQTT_GetShotVolume();
   bool heater = MQTT_GetHeaterState();
   bool steam = MQTT_GetSteamState();
+  bool ota = MQTT_GetOtaState();
 
   enum
   {
@@ -885,6 +909,8 @@ void example1_increase_lvgl_tick(lv_timer_t *t)
     lv_obj_set_style_bg_color(heater_btn, heater ? on : off, 0);
   if (steam_btn)
     lv_obj_set_style_bg_color(steam_btn, steam ? on : off, 0);
+  if (ota_btn)
+    lv_obj_set_style_bg_color(ota_btn, ota ? on : off, 0);
   if (settings_btn)
     lv_obj_set_style_bg_color(settings_btn, off, 0);
 }

--- a/firmware/display/src/Wireless/Wireless.h
+++ b/firmware/display/src/Wireless/Wireless.h
@@ -27,6 +27,8 @@ bool MQTT_GetHeaterState(void);
 void MQTT_SetHeaterState(bool state);
 bool MQTT_GetSteamState(void);
 void MQTT_SetSteamState(bool state);
+bool MQTT_GetOtaState(void);
+void MQTT_SetOtaState(bool state);
 
 bool Wireless_UsingEspNow(void);
 bool Wireless_IsMQTTConnected(void);


### PR DESCRIPTION
## Summary
- add Home Assistant switch and MQTT handling to toggle OTA window
- expose OTA toggle on settings screen with status colouring

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68c53c11350c833094bf5fec506a420a