### PR TITLE
Fix version bump workflow to tag after updating version.h

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -31,18 +31,14 @@ jobs:
           fi
           new_version="v$major.$minor.$patch"
           echo "version=$new_version" >> $GITHUB_OUTPUT
-      - name: Bump tag
-        id: tag
-        uses: mathieudutour/github-tag-action@v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ steps.bump.outputs.version }}
-      - name: Update version in firmware
+      - name: Update version and tag release
         run: |
-          version=${{ steps.bump.outputs.version }}
-          version=${version#v}
+          full_version=${{ steps.bump.outputs.version }}
+          version=${full_version#v}
           sed -i "s/#define VERSION \".*\"/#define VERSION \"${version}\"/" firmware/shared/include/version.h
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git commit -am "chore: release ${version}" || echo 'No changes'
-          git push
+          git tag -a "$full_version" -m "$full_version"
+          git push origin HEAD
+          git push origin "$full_version"


### PR DESCRIPTION
## Summary
- ensure bump-version workflow updates version.h before tagging
- create and push tag referencing commit with version.h

## Testing
- `yamllint .github/workflows/bump-version.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: 403 Client Error: Forbidden for url)*

------
https://chatgpt.com/codex/tasks/task_e_68c554a0b9d48330b78334a4cf2ab7a9