### PR TITLE
Rotate display and touch input 180 degrees

### DIFF
--- a/firmware/display/src/LCD_Driver/ST7701S.c
+++ b/firmware/display/src/LCD_Driver/ST7701S.c
@@ -492,6 +492,8 @@ void LCD_Init(void)
     ESP_LOGI(LCD_TAG, "Initialize RGB LCD panel");
     ESP_ERROR_CHECK(esp_lcd_panel_reset(panel_handle));
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
+    // Rotate display 180 degrees
+    ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, true, true));
     ST7701S_CS_Dis();
     Backlight_Init();
 }

--- a/firmware/display/src/Touch_Driver/CST820.c
+++ b/firmware/display/src/Touch_Driver/CST820.c
@@ -237,8 +237,8 @@ void Touch_Init(void)
         .int_gpio_num = I2C_Touch_INT_IO,
         .flags = {
             .swap_xy = 0,
-            .mirror_x = 0,
-            .mirror_y = 0,
+            .mirror_x = 1,
+            .mirror_y = 1,
         },
     };
     /* Initialize touch */


### PR DESCRIPTION
## Summary
- Rotate RGB panel output by 180° using `esp_lcd_panel_mirror`
- Mirror touch controller coordinates to match new orientation

## Testing
- `pio run` *(fails: command not found)*
- `pip install -U platformio` *(fails: could not find a version due to proxy error)*
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6656bc37883309dc40b8554c16fde