### PR TITLE
Display set temperature tick when heater active

### DIFF
--- a/firmware/display/src/LVGL_UI/LVGL_UI.c
+++ b/firmware/display/src/LVGL_UI/LVGL_UI.c
@@ -86,6 +86,7 @@ static lv_coord_t tab_h_global;
 static lv_obj_t *current_temp_arc;
 static lv_obj_t *set_temp_arc;
 static lv_obj_t *current_pressure_arc;
+static lv_obj_t *tick_layer;
 static lv_obj_t *temp_label;
 static lv_obj_t *pressure_label;
 static lv_obj_t *temp_icon;
@@ -114,6 +115,8 @@ static int last_conn_type = -1;
 static int last_conn_status = -1;
 static lv_timer_t *buzzer_timer;
 static bool shot_target_reached;
+static float set_temp_val;
+static bool heater_on;
 
 void Lvgl_Example1(void)
 {
@@ -444,6 +447,7 @@ void Lvgl_Example1_close(void)
   current_temp_arc = NULL;
   set_temp_arc = NULL;
   current_pressure_arc = NULL;
+  tick_layer = NULL;
   temp_label = NULL;
   pressure_label = NULL;
   temp_icon = NULL;
@@ -470,6 +474,8 @@ void Lvgl_Example1_close(void)
   shot_volume_label = NULL;
   shot_volume_slider = NULL;
   shot_volume_value = NULL;
+  set_temp_val = 0.0f;
+  heater_on = false;
 
   lv_style_reset(&style_text_muted);
   lv_style_reset(&style_title);
@@ -556,7 +562,7 @@ static void Status_create(lv_obj_t *parent)
   lv_arc_set_value(current_pressure_arc, 50);
 
   /* Ticks above arcs */
-  lv_obj_t *tick_layer = lv_obj_create(parent);
+  tick_layer = lv_obj_create(parent);
   lv_obj_set_size(tick_layer, LV_PCT(100), LV_PCT(100));
   lv_obj_set_style_bg_opa(tick_layer, LV_OPA_TRANSP, 0);
   lv_obj_set_style_border_width(tick_layer, 0, 0);
@@ -741,6 +747,30 @@ static void draw_ticks_cb(lv_event_t *e)
       lv_area_t a = {tp.x - 20, tp.y - 10, tp.x + 20, tp.y + 10};
       lv_draw_label(draw_ctx, &label_dsc, &a, buf, NULL);
     }
+
+    if (heater_on)
+    {
+      float v = set_temp_val;
+      if (!isnan(v))
+      {
+        if (v < TEMP_ARC_MIN)
+          v = TEMP_ARC_MIN;
+        else if (v > TEMP_ARC_MAX)
+          v = TEMP_ARC_MAX;
+        float angle = TEMP_ARC_START + (v - TEMP_ARC_MIN) *
+                                        TEMP_ARC_SIZE /
+                                        (float)(TEMP_ARC_MAX - TEMP_ARC_MIN);
+        float rad = angle * 3.14159265f / 180.0f;
+        lv_coord_t len = 20;
+        lv_point_t p1 = {cx + (lv_coord_t)((radius - len) * cosf(rad)),
+                         cy + (lv_coord_t)((radius - len) * sinf(rad))};
+        lv_point_t p2 = {cx + (lv_coord_t)(radius * cosf(rad)),
+                         cy + (lv_coord_t)(radius * sinf(rad))};
+        lv_draw_line_dsc_t red_dsc = line_dsc;
+        red_dsc.color = lv_palette_main(LV_PALETTE_RED);
+        lv_draw_line(draw_ctx, &red_dsc, &p1, &p2);
+      }
+    }
   }
 
   if (current_pressure_arc)
@@ -782,6 +812,11 @@ void example1_increase_lvgl_tick(lv_timer_t *t)
   bool heater = MQTT_GetHeaterState();
   bool steam = MQTT_GetSteamState();
   bool ota = MQTT_GetOtaState();
+
+  set_temp_val = set;
+  heater_on = heater;
+  if (tick_layer)
+    lv_obj_invalidate(tick_layer);
 
   enum
   {


### PR DESCRIPTION
## Summary
- keep tick drawing layer accessible and refreshed to reflect heater status
- force redraw when set temperature or heater state changes so the gauge shows a red tick
- reset tick layer pointer on close for clean teardown

## Testing
- `pio run` *(fails: command not found)*
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c672ee2890833094ec5437d0435b41