### PR TITLE
fix: publish active set temperature to MQTT

### DIFF
--- a/firmware/controller/src/gagguino.cpp
+++ b/firmware/controller/src/gagguino.cpp
@@ -1346,6 +1346,9 @@ static void mqttCallback(char* topic, uint8_t* payload, unsigned int len) {
         steamDispFlag = hv;
         steamResetPending = false;
         steamFlag = steamDispFlag || steamHwFlag;
+        // Update active setpoint to match current mode and reflect it via MQTT
+        setTemp = steamFlag ? steamSetpoint : brewSetpoint;
+        publishNum(t_settemp_state, setTemp, 1, true);
         publishBool(t_steam_state, steamFlag, true);
         LOG("HA: Steam -> %s", steamFlag ? "ON" : "OFF");
     }
@@ -1366,10 +1369,11 @@ static void mqttCallback(char* topic, uint8_t* payload, unsigned int len) {
         LOG("HA: OTA -> %s", otaActive ? "ON" : "OFF");
     }
     if (changed) {
-        if (!steamFlag) setTemp = brewSetpoint;  // if brewing, apply immediately
-        // reflect new values
+        // Update the active set temperature and mirror all setpoints
+        setTemp = steamFlag ? steamSetpoint : brewSetpoint;
         publishNum(t_brewset_state, brewSetpoint, 1, true);
         publishNum(t_steamset_state, steamSetpoint, 1, true);
+        publishNum(t_settemp_state, setTemp, 1, true);
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure steam-mode commands update and publish active set temperature
- publish new active set temperature whenever brew or steam setpoint changes

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c68bd6a170833089b59e2b1ab92073