### PR TITLE
fix: avoid I2C conflict with battery ADC channel

### DIFF
--- a/firmware/display/src/Battery/Battery.c
+++ b/firmware/display/src/Battery/Battery.c
@@ -3,7 +3,12 @@
 #include "esp_adc/adc_cali.h"
 #include "esp_adc/adc_cali_scheme.h"
 
-#define BAT_ADC_CHANNEL ADC_CHANNEL_6
+// Use ADC1 channel 5 (GPIO6) for battery sensing. Channel 6 (GPIO7)
+// clashes with the I2C SCL line used by the touch controller and
+// causes the bus to malfunction when the ADC is configured on that
+// pin. This matches the default pin assignment used in the Waveshare
+// demo firmware for the display module.
+#define BAT_ADC_CHANNEL ADC_CHANNEL_5
 #define BAT_ADC_ATTEN   ADC_ATTEN_DB_12
 
 static adc_oneshot_unit_handle_t adc_handle;


### PR DESCRIPTION
## Summary
- move battery monitor to ADC1 channel 5 (GPIO6) to avoid conflict with touch I2C bus
- document reason for channel selection and note alignment with Waveshare demo firmware

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install idf-component-manager` *(fails: proxy connection 403 / no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a20cdcd08330b1d03872d100a60a