### PR TITLE
Attach zero-cross interrupt when pump dimmer disabled

### DIFF
--- a/firmware/controller/src/gagguino.cpp
+++ b/firmware/controller/src/gagguino.cpp
@@ -1659,6 +1659,9 @@ void setup() {
     // double the pulse resolution.  CHANGE triggers the ISR on any
     // transition and `PULSE_MIN` guards against spurious bounce.
     attachInterrupt(digitalPinToInterrupt(FLOW_PIN), flowInt, CHANGE);
+#ifndef USE_PUMP_DIMMER
+    attachInterrupt(digitalPinToInterrupt(ZC_PIN), zcInt, RISING);
+#endif
 
     pulseCount = 0;
     startTime = millis();


### PR DESCRIPTION
## Summary
- attach the zero-cross ISR when the pump dimmer library is not in use so ZC events are tracked

## Testing
- not run (firmware change only)


------
https://chatgpt.com/codex/tasks/task_e_68c83a4dae5c833096ef68aba3c42ba4