### PR TITLE
Refactor comms for display-managed MQTT bridge

### DIFF
--- a/firmware/controller/include/espnow_packet.h
+++ b/firmware/controller/include/espnow_packet.h
@@ -1,22 +1,4 @@
 #pragma once
-#include <stdint.h>
 
-/**
- * @brief Packet describing brew/steam state for ESP-NOW transport.
- *
- * This structure is designed to be packed so it can be sent directly
- * over ESP-NOW without additional serialization. All numeric values are
- * little-endian.
- */
-struct __attribute__((packed)) EspNowPacket {
-    uint8_t shotFlag;        //!< 1 if a shot is in progress
-    uint8_t steamFlag;       //!< 1 if the machine is in steam mode
-    uint8_t heaterSwitch;    //!< Heater switch state (1=on)
-    uint32_t shotTimeMs;     //!< Shot duration in milliseconds
-    float shotVolumeMl;      //!< Volume pulled in milliliters
-    float setTempC;          //!< Currently configured temperature setpoint
-    float currentTempC;      //!< Current sensed temperature in °C
-    float pressureBar;       //!< Brew pressure in bar
-    float steamSetpointC;    //!< Steam temperature setpoint in °C
-    float brewSetpointC;     //!< Brew temperature setpoint in °C
-};
+#include "espnow_protocol.h"
+

--- a/firmware/display/src/Wireless/EspNowPacket.h
+++ b/firmware/display/src/Wireless/EspNowPacket.h
@@ -1,22 +1,4 @@
 #pragma once
-#include <stdint.h>
 
-/**
- * @brief Packet describing brew/steam state for ESP-NOW transport.
- *
- * This structure is designed to be packed so it can be sent directly
- * over ESP-NOW without additional serialization. All numeric values are
- * little-endian.
- */
-struct __attribute__((packed)) EspNowPacket {
-    uint8_t shotFlag;        //!< 1 if a shot is in progress
-    uint8_t steamFlag;       //!< 1 if the machine is in steam mode
-    uint8_t heaterSwitch;    //!< Heater switch state (1=on)
-    uint32_t shotTimeMs;     //!< Shot duration in milliseconds
-    float shotVolumeMl;      //!< Volume pulled in milliliters
-    float setTempC;          //!< Currently configured temperature setpoint
-    float currentTempC;      //!< Current sensed temperature in °C
-    float pressureBar;       //!< Brew pressure in bar
-    float steamSetpointC;    //!< Steam temperature setpoint in °C
-    float brewSetpointC;     //!< Brew temperature setpoint in °C
-};
+#include "espnow_protocol.h"
+

--- a/firmware/shared/include/espnow_protocol.h
+++ b/firmware/shared/include/espnow_protocol.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <stdint.h>
+
+// Common ESP-NOW protocol constants shared by the display and controller.
+
+// Handshake request emitted by the display. When the controller receives the
+// request it should switch to the supplied Wi-Fi channel (second byte) and reply
+// with ESPNOW_HANDSHAKE_ACK.
+#define ESPNOW_HANDSHAKE_REQ 0xAA
+
+// Handshake acknowledgement sent by the controller back to the display. The
+// second byte contains the controller's view of the active channel so the
+// display can detect mismatches and re-negotiate.
+#define ESPNOW_HANDSHAKE_ACK 0x55
+
+// Sent by the display after successfully processing a sensor packet.
+#define ESPNOW_SENSOR_ACK 0x5A
+
+// Identifier for control payloads pushed from the display to the controller.
+#define ESPNOW_CONTROL_PACKET 0xC0
+
+// Identifier for OTA enable/disable commands piggybacked on the control packet.
+#define ESPNOW_CONTROL_FLAG_HEATER   0x01
+#define ESPNOW_CONTROL_FLAG_STEAM    0x02
+#define ESPNOW_CONTROL_FLAG_OTA      0x04
+
+// Pump operating modes understood by the controller. The display always sends
+// one of these values in EspNowControlPacket::pumpMode.
+typedef enum {
+    ESPNOW_PUMP_MODE_NORMAL = 0,
+    ESPNOW_PUMP_MODE_PREINFUSE = 1,
+    ESPNOW_PUMP_MODE_MANUAL = 2,
+} EspNowPumpMode;
+
+// Packet describing brew/steam state for ESP-NOW transport. This struct must
+// remain byte-for-byte compatible with the legacy implementation so that both
+// ends can cast the payload directly.
+struct __attribute__((packed)) EspNowPacket {
+    uint8_t shotFlag;        //!< 1 if a shot is in progress
+    uint8_t steamFlag;       //!< 1 if the machine is in steam mode
+    uint8_t heaterSwitch;    //!< Heater switch state (1=on)
+    uint32_t shotTimeMs;     //!< Shot duration in milliseconds
+    float shotVolumeMl;      //!< Volume pulled in milliliters
+    float setTempC;          //!< Currently configured temperature setpoint
+    float currentTempC;      //!< Current sensed temperature in °C
+    float pressureBar;       //!< Brew pressure in bar
+    float steamSetpointC;    //!< Steam temperature setpoint in °C
+    float brewSetpointC;     //!< Brew temperature setpoint in °C
+};
+
+// Control payload mirrored between Home Assistant, the display and the
+// controller. The first byte must always be ESPNOW_CONTROL_PACKET.
+struct __attribute__((packed)) EspNowControlPacket {
+    uint8_t type;       //!< Constant ESPNOW_CONTROL_PACKET
+    uint8_t flags;      //!< Bitmask of ESPNOW_CONTROL_FLAG_*
+    uint8_t pumpMode;   //!< EspNowPumpMode value
+    uint8_t reserved;   //!< Reserved for future use / alignment
+    uint32_t revision;  //!< Monotonic revision to detect stale commands
+    float brewSetpointC;
+    float steamSetpointC;
+    float pidP;
+    float pidI;
+    float pidD;
+    float pumpPowerPercent;
+};
+


### PR DESCRIPTION
## Summary
- add a shared ESP-NOW protocol definition so the display and controller agree on handshake, telemetry and control payloads
- rewrite the display wireless stack to own MQTT, mirror Home Assistant state, initiate ESP-NOW handshakes on the STA channel and acknowledge telemetry while acting as the controller bridge
- update the controller firmware to consume the new control packet, fall back to safe defaults on link loss, and gate OTA availability from the display/UI
- surface simultaneous MQTT and ESP-NOW link status on the display UI

## Testing
- not run (PlatformIO toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc5779d1848330b5e071792abb7f1b