### PR TITLE
Remove controller OTA and use Wi-Fi only for NTP

### DIFF
--- a/firmware/controller/README.md
+++ b/firmware/controller/README.md
@@ -1,15 +1,14 @@
 Gagguino ESP – ESP32 Firmware for Gaggia Classic
 ================================================
 
-An ESP32-based controller for the Gaggia Classic espresso machine featuring PID temperature control (MAX31865 + PT100), flow/pressure/shot timing, and a robust ESP-NOW link to the companion display (which exposes MQTT/Home Assistant integration) alongside OTA updates.
+An ESP32-based controller for the Gaggia Classic espresso machine featuring PID temperature control (MAX31865 + PT100), flow/pressure/shot timing, and a robust ESP-NOW link to the companion display (which exposes MQTT/Home Assistant integration). Wi-Fi is used briefly at boot to synchronize the RTC via NTP before handing off entirely to the ESP-NOW display link.
 
 Features
 --------
 - PID temperature control using MAX31865 (PT100) with anti-windup and derivative on measurement.
 - Heater control via time-proportioning PWM windowing.
 - Flow pulses → volume, pressure sampling with moving average, and shot timing.
-- Wi‑Fi + ESP-NOW telemetry/control link to the display (display handles MQTT/Home Assistant discovery).
-- ArduinoOTA with safety handling (heater disabled during OTA).
+- ESP-NOW telemetry/control link to the display (display handles MQTT/Home Assistant discovery) with Wi‑Fi used only for NTP time sync.
 
 Hardware / Pinout (ESP32 dev board defaults)
 -------------------------------------------
@@ -39,15 +38,6 @@ Getting Started
 - Upload (USB): `pio run -t upload`
 - Monitor: `pio device monitor -b 115200`
 
-4) OTA uploads (Wi‑Fi)
-- `platformio.ini` includes an `esp32dev_ota` env with `upload_protocol = espota`.
-- Set your device IP in `upload_port` (e.g. `192.168.4.99`).
-- Upload over Wi‑Fi: `pio run -e esp32dev_ota -t upload`
-- Optional OTA password:
-  - In `platformio.ini` add build flag: `-D OTA_PASSWORD="your-password"` (or `OTA_PASSWORD_HASH`)
-  - Match the `--auth` flag under `upload_flags` for `espota`.
-- Enable OTA via the display before uploading (opens a ~5 min window and pauses normal telemetry).
-
 Tuning & Behavior
 -----------------
 - Brew setpoint limits: 90–99 °C. Steam setpoint limits: 145–155 °C (default 152 °C).
@@ -59,7 +49,6 @@ Troubleshooting
 ---------------
 - Serial monitor at `115200` shows boot logs, Wi‑Fi status, and optional periodic diagnostics.
 - MAX31865 diagnostics: firmware logs faults and raw/temperature reads to help validate wiring.
-- OTA: Device hostname is derived from MAC (e.g. `gaggia-ABCDEF`). During OTA the heater is forced off and other work is throttled.
 
 Safety
 ------
@@ -68,11 +57,11 @@ Safety
 
 Project Layout
 --------------
-- `src/gagguino.cpp` – main firmware logic, ESP-NOW, OTA, PID, sensors.
+- `src/gagguino.cpp` – main firmware logic, ESP-NOW, PID, sensors.
 - `src/gagguino.h` – public entry points for `setup()`/`loop()` in the `gag` namespace.
 - `src/main.cpp` – minimal sketch bridging Arduino to `gag::setup/loop`.
 - `src/secrets.h` – Wi‑Fi (and shared MQTT credentials for the display).
-- `platformio.ini` – environments, dependencies, and OTA settings.
+- `platformio.ini` – environments and build settings.
 
 License
 -------

--- a/firmware/controller/platformio.ini
+++ b/firmware/controller/platformio.ini
@@ -10,7 +10,7 @@
 
 
 [platformio]
-default_envs = esp32dev_ota
+default_envs = esp32dev
 
 [env:esp32dev]
 platform = espressif32
@@ -27,18 +27,3 @@ build_flags =
   ; CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH set in include/sdkconfig.h
 
 
-[env:esp32dev_ota]
-extends = env:esp32dev
-upload_protocol = espota
-upload_port = 192.168.4.99
-upload_flags =
-  --timeout=90
-
-; upload_flags = --auth=your-password
-; NOTE: To protect OTA with a password, define one at build time and
-; pass the same password to `espota.py` via `--auth` above.
-; In code, `ArduinoOTA` checks for either OTA_PASSWORD or OTA_PASSWORD_HASH.
-; Example (plaintext):
-;   build_flags = -D OTA_PASSWORD=\"your-password\"
-; Example (SHA1 hash from `arduinoOTA --hash` or similar):
-;   build_flags = -D OTA_PASSWORD_HASH=\"your-sha1-hash\"

--- a/firmware/controller/src/gagguino.h
+++ b/firmware/controller/src/gagguino.h
@@ -21,8 +21,7 @@ namespace gag {
  *
  * Responsibilities:
  * - Configure pins and peripherals (MAX31865, ADC, etc.).
- * - Start Wi‑Fi and establish the ESP-NOW link to the display.
- * - Initialize Over‑The‑Air (OTA) update handling once Wi‑Fi is ready.
+ * - Start Wi‑Fi briefly to synchronize NTP time, then establish the ESP-NOW link to the display.
  * - Calibrate/zero pressure intercept on boot if near atmospheric.
  */
 void setup();
@@ -33,7 +32,7 @@ void setup();
  * Runs frequently to:
  * - Update PID and PWM based heater control.
  * - Track flow, pressure, shot timing and steam state.
- * - Maintain Wi‑Fi, ESP-NOW and OTA sessions.
+ * - Maintain ESP-NOW connectivity with the display.
  * - Exchange telemetry with the display over ESP-NOW.
  */
 void loop();

--- a/firmware/shared/include/espnow_protocol.h
+++ b/firmware/shared/include/espnow_protocol.h
@@ -23,7 +23,7 @@
 // Identifier for OTA enable/disable commands piggybacked on the control packet.
 #define ESPNOW_CONTROL_FLAG_HEATER   0x01
 #define ESPNOW_CONTROL_FLAG_STEAM    0x02
-#define ESPNOW_CONTROL_FLAG_OTA      0x04
+#define ESPNOW_CONTROL_FLAG_OTA      0x04  //!< Reserved (legacy OTA enable)
 
 // Pump operating modes understood by the controller. The display always sends
 // one of these values in EspNowControlPacket::pumpMode.

--- a/firmware/shared/mqtt_spec.md
+++ b/firmware/shared/mqtt_spec.md
@@ -22,8 +22,8 @@ MQTT topic hierarchy.  All topics are rooted at:
 | `pressure/state` | pub by controller | Boiler pressure (bar) |
 | `shot_volume/state` | pub by controller | Shot volume (mL) |
 | `shot/state` | pub by controller | Shot active flag |
-| `ota/enable` | cmd to controller | Open OTA window |
-| `ota/status` | pub by controller | OTA status |
+| `ota/enable` | reserved | Former OTA control (unused) |
+| `ota/status` | reserved | Former OTA status (unused) |
 | `espnow/channel` | pub/sub | ESP‑NOW channel coordination |
 | `espnow/mac` | pub/sub | ESP‑NOW peer MAC |
 | `espnow/cmd` | pub/sub | ESP‑NOW control commands |


### PR DESCRIPTION
## Summary
- remove ArduinoOTA usage and OTA control handling from the controller firmware
- add a Wi-Fi helper that briefly associates to sync NTP time and pauses ESP-NOW scanning while connecting
- refresh documentation, shared headers, and PlatformIO config to reflect the OTA removal

## Testing
- not run (pio not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dec5bb393c8330bfc00f0f346bb4b4