### PR TITLE
Handle ESP-NOW channel switch on controller handshake

### DIFF
--- a/firmware/controller/src/gagguino.cpp
+++ b/firmware/controller/src/gagguino.cpp
@@ -638,7 +638,11 @@ static void espNowRecv(const uint8_t* mac, const uint8_t* data, int len) {
             memcpy(g_displayMac, mac, ESP_NOW_ETH_ALEN);
             g_haveDisplayPeer = true;
         }
-        g_espnowChannel = requestedChannel;
+
+        if (!applyEspNowChannel(requestedChannel, true, false)) {
+            LOG_ERROR("ESP-NOW: failed to switch to channel %u", requestedChannel);
+            return;
+        }
         g_espnowHandshake = true;
         g_espnowStatus = "linked";
         unsigned long nowMs = millis();


### PR DESCRIPTION
## Summary
- ensure the controller reapplies its ESP-NOW channel when a display handshake request is received
- abort the handshake if the channel change fails so we avoid sending on a mismatched channel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68decbd5ce988330824a43573b98faa3