### PR TITLE
Fix missing declaration for applyEspNowChannel

### DIFF
--- a/firmware/controller/src/gagguino.cpp
+++ b/firmware/controller/src/gagguino.cpp
@@ -238,6 +238,8 @@ static bool g_espnowScanning = false;
 static uint8_t g_nextScanChannel = ESPNOW_FIRST_CHANNEL;
 static unsigned long g_lastChannelHopMs = 0;
 
+static bool applyEspNowChannel(uint8_t channel, bool forceSetWifiChannel, bool silent);
+
 // ---------- helpers ----------
 /**
  * @brief Convert Wi-Fi status to a readable string.


### PR DESCRIPTION
## Summary
- add a forward declaration for `applyEspNowChannel` so it can be called earlier in the translation unit

## Testing
- `pio run` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ded16a19c883309f2d794a1beaec19