### PR TITLE
Remove OTA control from display and update MQTT logging

### DIFF
--- a/firmware/controller/src/gagguino.cpp
+++ b/firmware/controller/src/gagguino.cpp
@@ -557,12 +557,11 @@ static void applyControlPacket(const EspNowControlPacket& pkt, const uint8_t* ma
     if (pkt.revision && pkt.revision <= g_lastControlRevision) return;
     g_lastControlRevision = pkt.revision;
 
-    LOG("ESP-NOW: Control received rev %u: heater=%d steam=%d ota=%d brew=%.1f steamSet=%.1f "
+    LOG("ESP-NOW: Control received rev %u: heater=%d steam=%d brew=%.1f steamSet=%.1f "
         "pidP=%.2f pidI=%.2f "
         "pidD=%.2f pump=%.1f mode=%u",
         static_cast<unsigned>(pkt.revision), (pkt.flags & ESPNOW_CONTROL_FLAG_HEATER) != 0 ? 1 : 0,
-        (pkt.flags & ESPNOW_CONTROL_FLAG_STEAM) != 0 ? 1 : 0,
-        (pkt.flags & ESPNOW_CONTROL_FLAG_OTA) != 0 ? 1 : 0, pkt.brewSetpointC, pkt.steamSetpointC,
+        (pkt.flags & ESPNOW_CONTROL_FLAG_STEAM) != 0 ? 1 : 0, pkt.brewSetpointC, pkt.steamSetpointC,
         pkt.pidP, pkt.pidI, pkt.pidD, pkt.pumpPowerPercent, static_cast<unsigned>(pkt.pumpMode));
 
     bool hv = (pkt.flags & ESPNOW_CONTROL_FLAG_HEATER) != 0;

--- a/firmware/display/src/Wireless/Wireless.h
+++ b/firmware/display/src/Wireless/Wireless.h
@@ -29,8 +29,6 @@ bool MQTT_GetHeaterState(void);
 void MQTT_SetHeaterState(bool state);
 bool MQTT_GetSteamState(void);
 void MQTT_SetSteamState(bool state);
-bool MQTT_GetOtaState(void);
-void MQTT_SetOtaState(bool state);
 
 bool Wireless_UsingEspNow(void);
 bool Wireless_IsMQTTConnected(void);

--- a/firmware/shared/include/espnow_protocol.h
+++ b/firmware/shared/include/espnow_protocol.h
@@ -20,10 +20,9 @@
 // Identifier for control payloads pushed from the display to the controller.
 #define ESPNOW_CONTROL_PACKET 0xC0
 
-// Identifier for OTA enable/disable commands piggybacked on the control packet.
-#define ESPNOW_CONTROL_FLAG_HEATER   0x01
-#define ESPNOW_CONTROL_FLAG_STEAM    0x02
-#define ESPNOW_CONTROL_FLAG_OTA      0x04  //!< Reserved (legacy OTA enable)
+// Bit flags embedded in EspNowControlPacket::flags.
+#define ESPNOW_CONTROL_FLAG_HEATER 0x01
+#define ESPNOW_CONTROL_FLAG_STEAM  0x02
 
 // Pump operating modes understood by the controller. The display always sends
 // one of these values in EspNowControlPacket::pumpMode.


### PR DESCRIPTION
## Summary
- log inbound MQTT control commands before relaying them to the controller
- limit battery voltage logging to once every 30 seconds
- remove the OTA control path, including the display button and ESP-NOW flag, updating the controller to the revised packet

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfabdb765c8330978ba673e3d43f47