### PR TITLE
Replace comms status text with icon indicators

### DIFF
--- a/firmware/display/src/LVGL_UI/LVGL_UI.h
+++ b/firmware/display/src/LVGL_UI/LVGL_UI.h
@@ -8,6 +8,7 @@
 #include "Wireless.h"
 #include "Buzzer.h"
 #include "ST7701S.h"
+#include "fonts/mdi_icons_24.h"
 #include "fonts/mdi_icons_40.h"
 
 #define EXAMPLE1_LVGL_TICK_PERIOD_MS 1000

--- a/firmware/display/src/Wireless/Wireless.c
+++ b/firmware/display/src/Wireless/Wireless.c
@@ -942,6 +942,7 @@ void MQTT_SetSteamState(bool steam) {
 
 bool Wireless_UsingEspNow(void) { return s_use_espnow; }
 bool Wireless_IsMQTTConnected(void) { return s_mqtt_connected; }
+bool Wireless_IsWiFiConnected(void) { return s_wifi_ready; }
 
 bool Wireless_ControllerStillSendingEspNow(void) {
     if (!s_espnow_last_rx) return false;

--- a/firmware/display/src/Wireless/Wireless.h
+++ b/firmware/display/src/Wireless/Wireless.h
@@ -32,5 +32,6 @@ void MQTT_SetSteamState(bool state);
 
 bool Wireless_UsingEspNow(void);
 bool Wireless_IsMQTTConnected(void);
+bool Wireless_IsWiFiConnected(void);
 bool Wireless_ControllerStillSendingEspNow(void);
 bool Wireless_IsEspNowActive(void);


### PR DESCRIPTION
## Summary
- replace the text-based communication status area with 24px Wi-Fi, MQTT, and ESP-NOW icons that change colors per link state
- add a Wi-Fi connection accessor so the UI can reflect connectivity in the new icon row

## Testing
- not run (firmware changes)


------
https://chatgpt.com/codex/tasks/task_e_68dfca7129bc833087afe93fab20e2e9