### PR TITLE
Sync PID guard parameter via MQTT

### DIFF
--- a/firmware/shared/include/espnow_protocol.h
+++ b/firmware/shared/include/espnow_protocol.h
@@ -61,6 +61,7 @@ typedef struct __attribute__((packed)) EspNowControlPacket {
     float pidP;
     float pidI;
     float pidD;
+    float pidGuard;
     float pumpPowerPercent;
 } EspNowControlPacket;
 


### PR DESCRIPTION
## Summary
- add the PID guard field to ESP-NOW control packets and use it to update the controller
- publish and consume Home Assistant pid_guard topics while clamping PID parameters to zero or greater
- stop re-publishing default PID values on MQTT connect so retained settings override the boot defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e11732dec48330aa0c8a5cfcd9159a