### PR TITLE
Raise PID guard clamp to 100

### DIFF
--- a/firmware/controller/README.md
+++ b/firmware/controller/README.md
@@ -41,7 +41,7 @@ Getting Started
 Tuning & Behavior
 -----------------
 - Brew setpoint limits: 90–99 °C. Steam setpoint limits: 145–155 °C (default 152 °C).
-- PID defaults (overridable via display/ESP-NOW controls): `P=20.0`, `I=1.0`, `D=100.0`, `Guard=20.0`.
+- PID defaults (overridable via display/ESP-NOW controls): `P=20.0`, `I=1.0`, `D=100.0`, `Guard=100.0`.
 - Pressure: analog read with linear conversion; intercept is auto‑zeroed at boot if near 0 bar.
 - Heater: time‑proportioning window (`PWM_CYCLE`) with dynamic ON time from PID result.
 

--- a/firmware/controller/src/gagguino.cpp
+++ b/firmware/controller/src/gagguino.cpp
@@ -100,9 +100,9 @@ constexpr float RREF = 430.0f, RNOMINAL = 100.0f;
 // Kp: 15-16 [out/degC]
 // Ki: 0.3-0.5 [out/(degC*s)] -> start at 0.35
 // Kd: 50-70 [out*s/degC] -> start at 60
-// guard: +/-8-+/-12% integral clamp on 0-100% heater
+// guard: clamp integral term on 0-100% heater output (anti-windup)
 constexpr float P_GAIN_TEMP = 15.0f, I_GAIN_TEMP = 0.35f, D_GAIN_TEMP = 60.0f,
-                WINDUP_GUARD_TEMP = 10.0f;
+                WINDUP_GUARD_TEMP = 100.0f;
 // Derivative filter time constant (seconds), exposed to HA
 
 dimmerLamp pumpDimmer(PUMP_PIN, ZC_PIN);

--- a/firmware/shared/mqtt_spec.md
+++ b/firmware/shared/mqtt_spec.md
@@ -29,7 +29,7 @@ MQTT topic hierarchy.  All topics are rooted at:
 | `espnow/cmd` | pub/sub | ESP‑NOW control commands |
 | `brew_setpoint/set` & `.../state` | cmd/state | Brew temperature setpoint |
 | `steam_setpoint/set` & `.../state` | cmd/state | Steam temperature setpoint |
-| `pid_p`, `pid_i`, `pid_d`, `pid_guard`, `pid_d_tau` | cmd/state | PID tuning parameters |
+| `pid_p`, `pid_i`, `pid_d`, `pid_guard`, `pid_d_tau` | cmd/state | PID tuning parameters (`pid_guard` range 0–100) |
 | `status` | pub by controller & display | Availability ("online"/"offline") |
 | `error` | pub by controller | Aggregated error log |
 


### PR DESCRIPTION
## Summary
- raise the default integral windup guard in the controller PID to 100%
- document the new guard value in the controller README and note the 0–100 range in the shared MQTT topic spec

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e16ae5323483308295b9590d14f5a4