### PR TITLE
Fix PID dTau command topic prefix

### DIFF
--- a/firmware/display/src/Wireless/Wireless.c
+++ b/firmware/display/src/Wireless/Wireless.c
@@ -88,7 +88,7 @@ static inline void build_topics(void)
     snprintf(TOPIC_PIDG_STATE, sizeof TOPIC_PIDG_STATE, "%s/%s/pid_guard/state", GAG_TOPIC_ROOT, GAGGIA_ID);
     snprintf(TOPIC_PIDG_CMD, sizeof TOPIC_PIDG_CMD, "%s/%s/pid_guard/set", GAG_TOPIC_ROOT, GAGGIA_ID);
     snprintf(TOPIC_DTAU_STATE, sizeof TOPIC_DTAU_STATE, "%s/%s/pid_dtau/state", GAG_TOPIC_ROOT, GAGGIA_ID);
-    snprintf(TOPIC_DTAU_CMD, sizeof TOPIC_DTAU_CMD, "%s/%s/pid_stau/set", GAG_TOPIC_ROOT, GAGGIA_ID);
+    snprintf(TOPIC_DTAU_CMD, sizeof TOPIC_DTAU_CMD, "%s/%s/pid_dtau/set", GAG_TOPIC_ROOT, GAGGIA_ID);
     snprintf(TOPIC_PUMP_POWER_STATE, sizeof TOPIC_PUMP_POWER_STATE, "%s/%s/pump_power/state", GAG_TOPIC_ROOT, GAGGIA_ID);
     snprintf(TOPIC_PUMP_POWER_CMD, sizeof TOPIC_PUMP_POWER_CMD, "%s/%s/pump_power/set", GAG_TOPIC_ROOT, GAGGIA_ID);
     snprintf(TOPIC_PUMP_MODE_STATE, sizeof TOPIC_PUMP_MODE_STATE, "%s/%s/pump_mode/state", GAG_TOPIC_ROOT, GAGGIA_ID);


### PR DESCRIPTION
## Summary
- ensure the PID dTau command topic uses the pid_dtau prefix to match state and discovery topics

## Testing
- attempted `pio run` *(fails: command not found)*
- attempted `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e1803b977c8330a7573df2f7dfe308