### PR TITLE
Fix ESP-NOW control log formatting

### DIFF
--- a/firmware/display/src/Wireless/Wireless.c
+++ b/firmware/display/src/Wireless/Wireless.c
@@ -1136,11 +1136,11 @@ static void send_control_packet(void)
         s_control_dirty = false;
         ESP_LOGI(TAG_ESPNOW,
                  "Control sent rev %u: heater=%d steam=%d brew=%.1f steamSet=%.1f pidP=%.2f pidI=%.2f "
-                 "pidGuard=%.2f pidD=%.2f dTau = %.2f pump=%.1f mode=%u",
+                 "pidGuard=%.2f pidD=%.2f dTau=%0.2f pump=%.1f mode=%u",
                  (unsigned)revision, s_control.heater, s_control.steam,
                  (double)s_control.brewSetpoint, (double)s_control.steamSetpoint,
                  (double)s_control.pidP, (double)s_control.pidI, (double)s_control.pidGuard,
-                 (double)s_control.pidD, (double)s_control.pidGuard, (double)s_control.pumpPower, (unsigned)s_control.pumpMode);
+                 (double)s_control.pidD, (double)s_control.dTau, (double)s_control.pumpPower, (unsigned)s_control.pumpMode);
     }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated %0.2f placeholder to log the dTau field in control packets
- realign the ESP-NOW control packet log arguments so each value matches its formatter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e18039086c8330a26a0253077f5790