### PR TITLE
Refactor LVGL UI with reusable template and standby mode

### DIFF
--- a/firmware/display/src/LVGL_UI/LVGL_UI.c
+++ b/firmware/display/src/LVGL_UI/LVGL_UI.c
@@ -74,6 +74,7 @@ static void back_to_menu_event_cb(lv_event_t *e);
 static void standby_timer_cb(lv_timer_t *t);
 static void exit_standby_event_cb(lv_event_t *e);
 static void update_standby_clock(void);
+static void switch_to_screen(lv_obj_t *screen);
 
 void example1_increase_lvgl_tick(lv_timer_t *t);
 /**********************
@@ -237,7 +238,7 @@ void Lvgl_Example1(void)
   Settings_screen_create();
   Standby_screen_create();
 
-  lv_scr_load(menu_screen);
+  switch_to_screen(menu_screen);
 }
 
 void Lvgl_Example1_close(void)
@@ -406,7 +407,7 @@ static void template_set_back_handler(screen_template_t *tmpl, lv_event_cb_t cb,
   if (cb)
   {
     lv_obj_clear_flag(tmpl->back_btn, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_add_event_cb(tmpl->back_btn, cb, LV_EVENT_CLICKED, user_data);
+    lv_obj_add_event_cb(tmpl->back_btn, cb, LV_EVENT_RELEASED, user_data);
   }
   else
   {
@@ -599,7 +600,7 @@ static lv_obj_t *create_menu_button(lv_obj_t *parent, const char *text,
   lv_obj_set_height(btn, 54);
   lv_obj_set_style_border_width(btn, 0, 0);
   lv_obj_set_style_bg_color(btn, lv_palette_main(LV_PALETTE_GREY), 0);
-  lv_obj_add_event_cb(btn, cb, LV_EVENT_CLICKED, NULL);
+  lv_obj_add_event_cb(btn, cb, LV_EVENT_RELEASED, NULL);
 
   lv_obj_t *label = lv_label_create(btn);
   lv_label_set_text(label, text);
@@ -673,31 +674,31 @@ static void Standby_screen_create(void)
 static void menu_brew_event_cb(lv_event_t *e)
 {
   (void)e;
-  lv_scr_load(brew_screen);
+  switch_to_screen(brew_screen);
 }
 
 static void menu_steam_event_cb(lv_event_t *e)
 {
   (void)e;
-  lv_scr_load(steam_screen);
+  switch_to_screen(steam_screen);
 }
 
 static void menu_profiles_event_cb(lv_event_t *e)
 {
   (void)e;
-  lv_scr_load(profiles_screen);
+  switch_to_screen(profiles_screen);
 }
 
 static void menu_settings_event_cb(lv_event_t *e)
 {
   (void)e;
-  lv_scr_load(settings_screen);
+  switch_to_screen(settings_screen);
 }
 
 static void back_to_menu_event_cb(lv_event_t *e)
 {
   (void)e;
-  lv_scr_load(menu_screen);
+  switch_to_screen(menu_screen);
 }
 
 static void exit_standby_event_cb(lv_event_t *e)
@@ -741,8 +742,7 @@ void LVGL_Show_Standby(void)
     lv_timer_resume(standby_timer);
 
   update_standby_clock();
-  if (standby_screen)
-    lv_scr_load(standby_screen);
+  switch_to_screen(standby_screen);
 }
 
 void LVGL_Exit_Standby(void)
@@ -757,11 +757,21 @@ void LVGL_Exit_Standby(void)
   lv_obj_t *target = last_non_standby_screen ? last_non_standby_screen : brew_screen;
   if (!target)
     target = brew_screen;
-  if (target)
-    lv_scr_load(target);
+  switch_to_screen(target);
 }
 
 bool LVGL_Is_Standby_Active(void) { return standby_active; }
+
+static void switch_to_screen(lv_obj_t *screen)
+{
+  if (!screen)
+    return;
+
+  if (lv_scr_act() == screen)
+    return;
+
+  lv_scr_load(screen);
+}
 
 static void draw_ticks_cb(lv_event_t *e)
 {

--- a/firmware/display/src/LVGL_UI/LVGL_UI.c
+++ b/firmware/display/src/LVGL_UI/LVGL_UI.c
@@ -75,7 +75,6 @@ static void standby_timer_cb(lv_timer_t *t);
 static void exit_standby_event_cb(lv_event_t *e);
 static void update_standby_clock(void);
 static void switch_to_screen(lv_obj_t *screen);
-static void switch_to_screen_async_cb(void *user_data);
 
 void example1_increase_lvgl_tick(lv_timer_t *t);
 /**********************
@@ -112,8 +111,6 @@ static lv_obj_t *standby_time_label;
 static lv_timer_t *standby_timer;
 static lv_obj_t *last_non_standby_screen;
 static bool standby_active;
-
-static lv_obj_t *pending_screen_switch;
 
 static lv_obj_t *current_temp_arc;
 static lv_obj_t *set_temp_arc;
@@ -233,7 +230,6 @@ void Lvgl_Example1(void)
   standby_time_label = NULL;
   standby_active = false;
   last_non_standby_screen = NULL;
-  pending_screen_switch = NULL;
 
   Brew_screen_create();
   Menu_screen_create();
@@ -305,7 +301,6 @@ void Lvgl_Example1_close(void)
   standby_screen = NULL;
   active_template = NULL;
   last_non_standby_screen = NULL;
-  pending_screen_switch = NULL;
 
   lv_style_reset(&style_text_muted);
   lv_style_reset(&style_title);
@@ -768,20 +763,6 @@ void LVGL_Exit_Standby(void)
 
 bool LVGL_Is_Standby_Active(void) { return standby_active; }
 
-static void switch_to_screen_async_cb(void *user_data)
-{
-  lv_obj_t *screen = (lv_obj_t *)user_data;
-  pending_screen_switch = NULL;
-
-  if (!screen)
-    return;
-
-  if (lv_scr_act() == screen)
-    return;
-
-  lv_scr_load(screen);
-}
-
 static void switch_to_screen(lv_obj_t *screen)
 {
   if (!screen)
@@ -790,11 +771,7 @@ static void switch_to_screen(lv_obj_t *screen)
   if (lv_scr_act() == screen)
     return;
 
-  if (pending_screen_switch == screen)
-    return;
-
-  pending_screen_switch = screen;
-  lv_async_call(switch_to_screen_async_cb, screen);
+  lv_scr_load(screen);
 }
 
 static void draw_ticks_cb(lv_event_t *e)

--- a/firmware/display/src/LVGL_UI/LVGL_UI.h
+++ b/firmware/display/src/LVGL_UI/LVGL_UI.h
@@ -30,3 +30,6 @@ void Backlight_adjustment_event_cb(lv_event_t *e);
 
 void Lvgl_Example1(void);
 void LVGL_Backlight_adjustment(uint8_t Backlight);
+void LVGL_Show_Standby(void);
+void LVGL_Exit_Standby(void);
+bool LVGL_Is_Standby_Active(void);

--- a/firmware/display/src/LVGL_UI/LVGL_UI.h
+++ b/firmware/display/src/LVGL_UI/LVGL_UI.h
@@ -33,3 +33,4 @@ void LVGL_Backlight_adjustment(uint8_t Backlight);
 void LVGL_Show_Standby(void);
 void LVGL_Exit_Standby(void);
 bool LVGL_Is_Standby_Active(void);
+void LVGL_UI_PollTelemetry(void);

--- a/firmware/display/src/main.c
+++ b/firmware/display/src/main.c
@@ -51,7 +51,7 @@ volatile TickType_t g_last_touch_tick = 0;
 static TickType_t last_heater_on_tick = 0;
 static TickType_t last_zc_change_tick = 0;
 static uint32_t last_zc_count = 0;
-static bool lcd_backlight_off = false;
+#define LCD_STANDBY_BACKLIGHT 5
 
 #define LCD_INACTIVITY_TIMEOUT  pdMS_TO_TICKS(300000)  /* 5 min inactivity window */
 
@@ -126,16 +126,16 @@ void app_main(void)
         bool heater_inactive = !heater_on && (now - last_heater_on_tick) >= LCD_INACTIVITY_TIMEOUT;
         bool zc_inactive = (now - last_zc_change_tick) >= LCD_INACTIVITY_TIMEOUT;
 
-        if (!lcd_backlight_off) {
+        if (!LVGL_Is_Standby_Active()) {
             if (touch_inactive && (heater_inactive || zc_inactive)) {
-                Set_Backlight(0);
-                lcd_backlight_off = true;
+                LVGL_Show_Standby();
+                Set_Backlight(LCD_STANDBY_BACKLIGHT);
             }
         } else {
             bool touch_recent = !touch_inactive;
             if (heater_on || zc_changed || touch_recent) {
+                LVGL_Exit_Standby();
                 Set_Backlight(LCD_Backlight);
-                lcd_backlight_off = false;
             }
         }
     }

--- a/firmware/display/src/main.c
+++ b/firmware/display/src/main.c
@@ -88,6 +88,7 @@ void app_main(void)
     LVGL_Init();     // Initialize graphics library
 /********************* Demo *********************/
     Lvgl_Example1();
+    LVGL_UI_PollTelemetry();
 
     // Alternative demos:
     // lv_demo_widgets();
@@ -107,6 +108,7 @@ void app_main(void)
     while (1) {
         // Run lv_timer_handler every 250 ms
         vTaskDelay(pdMS_TO_TICKS(250));
+        LVGL_UI_PollTelemetry();
         lv_timer_handler();
 
         TickType_t now = xTaskGetTickCount();


### PR DESCRIPTION
## Summary
- add a reusable screen template that provides the connection status icons, footer controls, and back navigation for brew, menu, placeholder, and standby screens
- create a main menu plus steam, profiles, and settings placeholders while keeping the brew gauges intact
- replace the display power-off routine with a standby clock screen and dimmed backlight recovery logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e17bdf76708330aa14869f37afdcb9