### PR TITLE
Add menu navigation and standby mode

### DIFF
--- a/firmware/display/src/LVGL_UI/LVGL_UI.c
+++ b/firmware/display/src/LVGL_UI/LVGL_UI.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 #include "esp_log.h"
 #include "esp_system.h"
 #include "version.h"

--- a/firmware/display/src/LVGL_UI/LVGL_UI.h
+++ b/firmware/display/src/LVGL_UI/LVGL_UI.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "lvgl.h"
+#include <stdbool.h>
 // #include "demos/lv_demos.h"
 
 #include "LVGL_Driver.h"
@@ -30,3 +31,6 @@ void Backlight_adjustment_event_cb(lv_event_t *e);
 
 void Lvgl_Example1(void);
 void LVGL_Backlight_adjustment(uint8_t Backlight);
+void LVGL_EnterStandby(void);
+void LVGL_ExitStandby(void);
+bool LVGL_IsStandbyActive(void);


### PR DESCRIPTION
## Summary
- rename the main display screen to a dedicated brew screen and add a menu screen with navigation
- replace the existing settings UI with placeholders for settings, steam, and profiles that link back to the menu
- introduce a standby screen that shows the current time and dims the backlight instead of powering the display off

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1b1358dec83308bc82cd65f798a7b