### PR TITLE
Update menu and brew UI layout

### DIFF
--- a/firmware/display/src/LVGL_UI/LVGL_UI.h
+++ b/firmware/display/src/LVGL_UI/LVGL_UI.h
@@ -11,6 +11,7 @@
 #include "ST7701S.h"
 #include "fonts/mdi_icons_24.h"
 #include "fonts/mdi_icons_40.h"
+#include "fonts/mdi_icons_80.h"
 
 #define EXAMPLE1_LVGL_TICK_PERIOD_MS 1000
 #define TEMP_ARC_START 120


### PR DESCRIPTION
## Summary
- add Wi-Fi, MQTT, and ESP-Now status indicators to the menu screen
- replace the vertical menu list with a 2x2 grid of square buttons featuring 80px MDI icons
- remove brew screen heat/steam/settings controls and center the home button above the battery meter

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e28a3428cc8330aafc7df163548c94