### PR TITLE
Improve standby behaviour and menu layout

### DIFF
--- a/firmware/display/src/main.c
+++ b/firmware/display/src/main.c
@@ -134,8 +134,7 @@ void app_main(void)
                 standby_mode = true;
             }
         } else {
-            bool touch_recent = !touch_inactive;
-            if (heater_on || zc_changed || touch_recent) {
+            if (!touch_inactive) {
                 LVGL_ExitStandby();
                 Set_Backlight(LCD_Backlight);
                 standby_mode = false;


### PR DESCRIPTION
## Summary
- localise the standby clock to UK time with DST handling and shareable helpers
- centre the menu button grid, shrink the buttons, and align communication icons with the brew screen
- enhance the standby screen with aligned icons, a larger clock, dim backlight, and keep it active until touch

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e2a7867e608330a6e01935f1e9a856