### PR TITLE
Add pump power telemetry over ESP-NOW and MQTT

### DIFF
--- a/firmware/controller/src/gagguino.cpp
+++ b/firmware/controller/src/gagguino.cpp
@@ -656,6 +656,7 @@ static void sendEspNowPacket() {
     pkt.pidPTerm = pidPTerm;
     pkt.pidITerm = pidITerm;
     pkt.pidDTerm = pidDTerm;
+    pkt.pumpPowerPercent = lastPumpApplied;
     const uint8_t* dest = g_haveDisplayPeer ? g_displayMac : nullptr;
     esp_err_t err = esp_now_send(dest, reinterpret_cast<uint8_t*>(&pkt), sizeof(pkt));
     if (err != ESP_OK) {

--- a/firmware/shared/include/espnow_protocol.h
+++ b/firmware/shared/include/espnow_protocol.h
@@ -55,6 +55,7 @@ typedef struct __attribute__((packed)) EspNowPacket
     float pidPTerm;            //!< Proportional contribution of the temperature PID
     float pidITerm;            //!< Integral contribution of the temperature PID
     float pidDTerm;            //!< Derivative contribution of the temperature PID
+    float pumpPowerPercent;    //!< Actual pump power being applied (0-100%)
 } EspNowPacket;
 
 // Control payload mirrored between Home Assistant, the display and the


### PR DESCRIPTION
## Summary
- extend the shared ESP-NOW telemetry packet to include the actual pump power percentage
- send the controller's applied pump power and expose it through the display's MQTT telemetry
- add Home Assistant discovery for the pump power output sensor and avoid redundant publishes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ed56c5e4b083309ff34b553d319f4c