### PR TITLE
Add pump and valve relay control via ESP-NOW and MQTT

### DIFF
--- a/firmware/shared/include/espnow_protocol.h
+++ b/firmware/shared/include/espnow_protocol.h
@@ -24,6 +24,8 @@
 #define ESPNOW_CONTROL_FLAG_HEATER 0x01
 #define ESPNOW_CONTROL_FLAG_STEAM 0x02
 #define ESPNOW_CONTROL_FLAG_PUMP_PRESSURE 0x04
+#define ESPNOW_CONTROL_FLAG_PUMP_RELAY 0x08
+#define ESPNOW_CONTROL_FLAG_VALVE_RELAY 0x10
 
 // Pump operating modes understood by the controller. The display always sends
 // one of these values in EspNowControlPacket::pumpMode.


### PR DESCRIPTION
## Summary
- add shared ESP-NOW control flags for the pump and valve relays
- drive the new relays on the controller firmware and expose their state to MQTT
- publish Home Assistant discovery, state, and command handling for the new relay switches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69008f2a187083309aa5d171bd894900