### PR TITLE
Add Home Assistant pump and valve relay controls

### DIFF
--- a/firmware/display/src/Wireless/Wireless.h
+++ b/firmware/display/src/Wireless/Wireless.h
@@ -24,6 +24,8 @@ float MQTT_GetSetTemp(void);
 float MQTT_GetCurrentPressure(void);
 float MQTT_GetSetPressure(void);
 bool MQTT_GetPumpPressureMode(void);
+bool MQTT_GetPumpRelayState(void);
+bool MQTT_GetValveRelayState(void);
 float MQTT_GetPumpPower(void);
 float MQTT_GetShotTime(void);
 float MQTT_GetShotVolume(void);
@@ -35,6 +37,8 @@ void MQTT_SetHeaterState(bool state, bool force_publish);
 bool MQTT_GetSteamState(void);
 void MQTT_SetSteamState(bool state);
 void MQTT_SetPumpPressureMode(bool enabled);
+void MQTT_SetPumpRelayState(bool enabled);
+void MQTT_SetValveRelayState(bool enabled);
 void MQTT_SetPressureSetpoint(float pressure);
 void MQTT_SetPumpPower(float power);
 

--- a/firmware/shared/include/espnow_protocol.h
+++ b/firmware/shared/include/espnow_protocol.h
@@ -24,6 +24,8 @@
 #define ESPNOW_CONTROL_FLAG_HEATER 0x01
 #define ESPNOW_CONTROL_FLAG_STEAM 0x02
 #define ESPNOW_CONTROL_FLAG_PUMP_PRESSURE 0x04
+#define ESPNOW_CONTROL_FLAG_PUMP_RELAY 0x08
+#define ESPNOW_CONTROL_FLAG_VALVE_RELAY 0x10
 
 // Packet describing brew/steam state for ESP-NOW transport. This struct must
 // remain byte-for-byte compatible with the legacy implementation so that both


### PR DESCRIPTION
## Summary
- add new ESP-NOW control flags for the pump and valve relays
- expose the relay states via MQTT with Home Assistant discovery and helper APIs on the display
- drive the physical relays on the controller when the new flags are received

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_69009a52f6088330abf0b21c39315c36